### PR TITLE
fix: remove margin-top for nested unordered lists

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -1613,6 +1613,10 @@ footer {
     margin-left: 30px;
     margin-top: 20px;
   }
+
+  ul ul {
+    margin-top: 0px;
+  }
 }
 .entry {
   margin: 0 auto 1.85rem;


### PR DESCRIPTION
## Info

* Fixes the issue we're seeing here: https://github.com/masterpointio/masterpoint.io/pull/16#discussion_r1471312740
* Here is what it will look like now: 
![CleanShot 2024-01-30 at 10 10 32](https://github.com/masterpointio/masterpoint.io/assets/1392040/111332a0-f4e8-4f36-a486-4d64890d8d4e)


