### PR TITLE
fix: sets the #thank-you background to our dark green to fix it being drowned out in white

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,13 @@
+---
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+- type: standard
+  ref: v4.190.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: gohugoio/hugo/hugo-extended@v0.127.0

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -751,7 +751,7 @@ header {
           color: #ffffff;
           padding: 1px 6.6px;
           position: relative;
-          
+
 
           &.current-menu-item {
             &:before {
@@ -2394,6 +2394,8 @@ footer {
 }
 
 #thank-you {
+  background: rgb(0, 51, 51);
+
   #banner {
     h2 {
       font-size: 2em;
@@ -2500,7 +2502,7 @@ footer {
   &.noBannerImg {
     #banner {
       &:before {
-        
+
         position: absolute;
         left: 0;
         top: 0;
@@ -2508,8 +2510,8 @@ footer {
         height: 100%;
         content: "";
         z-index: 2;
-  
-        
+
+
           background: linear-gradient(
             360deg,
             rgba(0, 0, 0, 0.3) 0%,
@@ -2517,7 +2519,7 @@ footer {
           ),
           linear-gradient(360deg, $pine 40%, rgba(14, 56, 58, 0.4) 120%);
         }
-      
+
 
       .bannerTxtBx {
         margin: 0 auto;


### PR DESCRIPTION
# Info

* A colleague just reported this after scheduling a meeting with me. Check out https://masterpoint.io/thank-you/meeting-confirmed/. Does not look great! 
![CleanShot 2024-06-07 at 16 12 30](https://github.com/masterpointio/masterpoint.io/assets/1392040/0f72e9a5-334c-47bf-a754-58c12d646485)
* Used `git bisect` to find the offending commit and tracked it down to the `background` color being set to white on all pages via https://github.com/masterpointio/masterpoint.io/commit/50cdaed539b355a066a96a1f8caf40e54634df03#diff-0cc42738c953218500f377a0ee933c7511a34b0cb7eadbe4a6c156b3ee59e64bR7-R10, which didn't affect anywhere else on the site except the thank-you pages. Not entirely sure why... but fixing this by being explicit on that page!
* Added `aqua.yaml` so we can easily install `hugo` (extended)