### PR TITLE
fix(blog): extra padding on callout

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -1707,6 +1707,10 @@ footer {
       border-radius:3px;
       border:3px solid $highlight;
       margin-top:24px;
+
+      p {
+        margin-bottom: 0;
+      }
     }
   }
   .postMeta {


### PR DESCRIPTION
This is nested into the #callout so this only affects the blog article callout items.

This also exists in current blog posts where we use the callout, example https://masterpoint.io/updates/terraform-use-cases/

Before:
![image](https://github.com/user-attachments/assets/36181129-87f0-4d0b-9bcf-298816de4b5e)

After: 
![image](https://github.com/user-attachments/assets/293d810d-8847-4203-a762-d0500e1c3f1b)
