### PR TITLE
fix: remove extra https from gobetween /now page link

### DIFF
--- a/content/now/_index.md
+++ b/content/now/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Masterpoint <span class='text-gradient'>Now</span>"
 description: Find out the latest personal updates from the Masterpoint Team
-banner_text: "<a href=\"https://nownownow.com/about\">Inspired by Derek Sivers</a> and our friends at <a href=\"https://https://gobetweenlabs.com/now/\">Go Between</a>, this /now page shares a bit more about what Matt and the Masterpoint team are up to right now. This content is updated every 6 months and was last updated in April 2025"
+banner_text: "<a href=\"https://nownownow.com/about\">Inspired by Derek Sivers</a> and our friends at <a href=\"https://gobetweenlabs.com/now/\">Go Between</a>, this /now page shares a bit more about what Matt and the Masterpoint team are up to right now. This content is updated every 6 months and was last updated in April 2025"
 last_update: April 2025
 id: nowPage
 banner_btn_label: Let's Chat!


### PR DESCRIPTION
## what

- @trumanshuck pointed this out in Slack

## why

- Broken links are lame!

## references

- Slack convo with Truman: https://masterpoint.slack.com/archives/C04S1SB9A93/p1744918774951279?thread_ts=1744917883.259029&cid=C04S1SB9A93
