### PR TITLE
feat(trunk): add trunk + workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Use this file to define individuals or teams that are responsible for code in a repository.
+# Read more: <https://help.github.com/articles/about-codeowners/>
+#
+# Order is important: the last matching pattern takes the most precedence
+
+# These owners will be the default owners for everything
+*             @masterpointio/masterpoint-open-source

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## what
+
+- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
+- Use bullet points to be concise and to the point.
+
+## why
+
+- Provide the justifications for the changes (e.g. business case).
+- Describe why these changes were made (e.g. why do these commits fix the problem?)
+- Use bullet points to be concise and to the point.
+
+## references
+
+- Link to any supporting GitHub issues or helpful documentation to add some context (e.g. Stackoverflow).
+- Use `closes #123`, if this PR closes a GitHub issue `#123`

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,31 @@
+{
+  "extends": [
+    "config:best-practices",
+    "github>aquaproj/aqua-renovate-config#2.7.5"
+  ],
+  "enabledManagers": [
+    "github-actions"
+  ],
+  "schedule": [
+    "after 9am on the first day of the month"
+  ],
+  "assigneesFromCodeOwners": true,
+  "dependencyDashboardAutoclose": true,
+  "addLabels": ["{{manager}}"],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "branch",
+      "groupName": "github-actions-auto-upgrade",
+      "addLabels": ["auto-upgrade"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "github-actions-needs-review",
+      "addLabels": ["needs-review"]
+    }
+  ]
+}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,29 @@
+name: Lint
+
+concurrency:
+  group: lint-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on: pull_request
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Trunk Check
+        uses: trunk-io/trunk-action@4d5ecc89b2691705fd08c747c78652d2fc806a94 # v1.1.19
+
+  conventional-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -1,0 +1,43 @@
+name: Trunk Upgrade
+
+on:
+  schedule:
+    # On the first day of every month @ 8am
+    - cron: 0 8 1 * *
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  trunk-upgrade:
+    runs-on: ubuntu-latest
+    permissions:
+      # For trunk to create PRs
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Create Token for MasterpointBot App
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
+        id: generate-token
+        with:
+          app_id: ${{ secrets.MP_BOT_APP_ID }}
+          private_key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
+
+      - name: Upgrade
+        id: trunk-upgrade
+        uses: trunk-io/trunk-action/upgrade@4d5ecc89b2691705fd08c747c78652d2fc806a94 # v1.1.19
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          reviewers: "@masterpointio/masterpoint-internal"
+          prefix: "chore: "
+
+      - name: Merge PR automatically
+        if: steps.trunk-upgrade.outputs.pull-request-number != ''
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_NUMBER: ${{ steps.trunk-upgrade.outputs.pull-request-number }}
+        run: |
+          gh pr merge "$PR_NUMBER" --squash --auto --delete-branch

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,9 @@
+*out
+*logs
+*actions
+*notifications
+*tools
+plugins
+user_trunk.yaml
+user.yaml
+tmp

--- a/.trunk/configs/.markdownlint.yaml
+++ b/.trunk/configs/.markdownlint.yaml
@@ -1,0 +1,13 @@
+# Autoformatter friendly markdownlint config (all formatting rules disabled)
+default: true
+blank_lines: false
+bullet: false
+html: false
+indentation: false
+line_length: false
+spaces: false
+url: false
+whitespace: false
+
+# Disable MD025: Multiple top-level headings in the same file
+MD025: false

--- a/.trunk/configs/.yamllint.yaml
+++ b/.trunk/configs/.yamllint.yaml
@@ -1,0 +1,10 @@
+rules:
+  quoted-strings:
+    required: only-when-needed
+    extra-allowed: ["{|}"]
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
+  key-duplicates: {}
+  octal-values:
+    forbid-implicit-octal: true

--- a/.trunk/configs/svgo.config.js
+++ b/.trunk/configs/svgo.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  plugins: [
+    {
+      name: "preset-default",
+      params: {
+        overrides: {
+          removeViewBox: false, // https://github.com/svg/svgo/issues/1128
+          sortAttrs: true,
+          removeOffCanvasPaths: true,
+        },
+      },
+    },
+  ],
+};

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,32 @@
+version: 0.1
+cli:
+  version: 1.22.15
+plugins:
+  sources:
+    - id: trunk
+      ref: v1.6.8
+      uri: https://github.com/trunk-io/plugins
+lint:
+  enabled:
+    - checkov@3.2.427
+    - trufflehog@3.88.30
+    - git-diff-check
+    - gitleaks@8.26.0
+    - markdownlint@0.45.0
+    - oxipng@9.1.5
+    - prettier@3.5.3
+    - svgo@3.3.2
+    - taplo@0.9.3
+    - yamllint@1.37.1
+runtimes:
+  enabled:
+    - go@1.21.0
+    - node@18.20.5
+    - python@3.10.8
+actions:
+  disabled:
+    - trunk-announce
+    - trunk-check-pre-push
+    - trunk-fmt-pre-commit
+  enabled:
+    - trunk-upgrade-available

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,6 +18,10 @@ lint:
     - svgo@3.3.2
     - taplo@0.9.3
     - yamllint@1.37.1
+  ignore:
+    - linters: [ALL]
+      paths:
+        - "**/PULL_REQUEST_TEMPLATE.md"
 runtimes:
   enabled:
     - go@1.21.0


### PR DESCRIPTION
## what

- Adds trunk's config for this repo.
- Adds trunk workflows for linting + upgrading trunk configs
- Adds renovate
- Adds CODEOWNERS

## why

- Other PRs are blocked because we're requiring the `lint` GHA check. This repo never got updated to include that so fixing that now 👍

## references

- See this blog post PR which is blocked due to the `lint` requirement: https://github.com/masterpointio/masterpoint.io/pull/49


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added repository ownership rules to assign default code owners.
	- Introduced a pull request template to standardize PR submissions.
	- Added Renovate configuration for automated GitHub Actions dependency updates.
	- Set up GitHub Actions workflows for linting and automated Trunk upgrades.
	- Added `.gitignore` and configuration files for Trunk, markdownlint, yamllint, and SVGO to support consistent development and code quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->