### PR TITLE
feat: blog preview links use article image

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -47,6 +47,9 @@
     {{ if .Params.og_img }}
     <meta property="og:image" content='{{ .Params.og_img }}'/>
     <meta property="twitter:image" content='{{ .Params.og_img }}'/>
+    {{ else if .Params.image }}
+    <meta property="og:image" content='{{ .Params.image }}'/>
+    <meta property="twitter:image" content='{{ .Params.image }}'/>
     {{ else }}
     <meta property="og:image" content="/img/og-img.png"/>
     <meta property="twitter:image" content="/img/og-img.png"/>


### PR DESCRIPTION
Putting this up for PR first to test the preview

For blog articles, we want to use the image in the article as the preview instead of the default.

Reference: https://www.notion.so/masterpoint/Update-so-the-preview-image-on-all-blog-posts-is-the-header-image-when-links-are-unfurled-1ee859758a5680bc9796d97b50a5d9d7