### PR TITLE
feat: add author meta tags for blog articles

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -63,7 +63,7 @@
     />
     {{end}}
 
-    {{ if and (eq .Section "blog") .Params.author }}
+    {{ if and (eq .Section "blog") (.Params.author) }}
     <meta name="author" content="{{ .Params.author }}" />
     {{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -61,9 +61,7 @@
       name="twitter:description"
       content="{{ .Description | plainify | truncate 155 }}"
     />
-    {{end}}
-
-    {{ if and (eq .Section "blog") (.Params.author) }}
+    {{end}} {{ if and (eq .Section "blog") (.Params.author) }}
     <meta name="author" content="{{ .Params.author }}" />
     {{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -63,6 +63,10 @@
     />
     {{end}}
 
+    {{ if and (eq .Section "blog") .Params.author }}
+    <meta name="author" content="{{ .Params.author }}" />
+    {{ end }}
+
     <meta property="og:url" content="{{ .Permalink }}" />
     <meta name="twitter:url" content="{{ .Permalink }}" />
 


### PR DESCRIPTION
Add the author meta tags for blog articles. Don't think it helps a lot but I thought of this as I saw it on news/article websites 

https://www.geeksforgeeks.org/websites-apps/10-most-important-meta-tags-for-seo/#10-meta-author-tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blog posts now include an author meta tag when an author is specified, improving attribution and richer link previews.
  * The meta tag is only added for blog content and is omitted elsewhere, so non-blog pages are unchanged.
  * No configuration required; posts without an author remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->