### PR TITLE
feat(blog): last modified date & SEO improvements for blog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,16 +20,21 @@ hugo serve
 # Build the site for production
 hugo --gc --minify
 
-# Create new content
-hugo new blog/my-new-post.md
+# Create new content (blog posts use date-prefixed naming)
+hugo new blog/$(date +%Y-%m-%d)-my-new-post.md
 hugo new case-studies/client-name.md
+
+# Lint and format code
+trunk check
+trunk fmt
 ```
 
 ### Local Development
 
 - Server runs on: `http://localhost:1313`
-- Hugo Extended is required (managed via Aqua)
+- Hugo Extended v0.145.0 is required (managed via Aqua)
 - No npm/yarn commands - this is a pure Hugo project
+- Trunk is used for linting (markdownlint, prettier, checkov, etc.)
 
 ## Architecture Overview
 
@@ -76,6 +81,7 @@ draft: false
 title: "The Platform Engineering Way to Manage Google Workspace Users"
 author: Weston Platter
 date: 2025-07-17
+date_modified: 2025-07-19  # Optional: Shows "Updated" date if different from publish date
 slug: platform-engineering-way-to-manage-google-workspace-users
 description: "Migrate Google Workspace from ClickOps to Infrastructure as Code with our open source Terraform module. Includes design patterns and import examples."
 tags: ["terraform", "google-workspace", "infrastructure-as-code", "automation"]
@@ -87,11 +93,37 @@ callout: <p>👋 <b>If you're ready to take your infrastructure to the next leve
 
 ### Custom Shortcodes
 
-- `{{< youtube VIDEO_ID >}}` - Embed YouTube videos
-- `{{< form formName="contact" >}}` - Contact forms
-- `{{< testimonial >}}` - Client testimonials
-- `{{< faq >}}` - FAQ sections
 - `{{< button link="/path" text="CTA Text" >}}` - Call-to-action buttons
+- `{{< buttonout link="https://external.com" text="External Link" >}}` - External buttons
+- `{{< form formName="contact" >}}` - Contact forms
+- `{{< testimonials >}}` - Client testimonials
+- `{{< faqs >}}` - FAQ sections
+- `{{< team >}}` - Team member displays
+- `{{< services >}}` - Service listings
+- `{{< process >}}` - Process steps
+- `{{< supports >}}` - Support/technology logos
+- `{{< client-logos >}}` - Client logo displays
+
+## Code Quality & Linting
+
+The project uses Trunk for code quality management with multiple linters:
+
+- **Markdown**: markdownlint with custom config (`.markdownlint.yaml`)
+- **YAML**: yamllint for configuration files
+- **Security**: checkov for infrastructure security, gitleaks for secrets
+- **Formatting**: prettier for consistent code style
+- **Images**: oxipng for PNG optimization, svgo for SVG optimization
+
+```bash
+# Run all linters
+trunk check
+
+# Auto-fix issues where possible
+trunk fmt
+
+# Check specific files
+trunk check path/to/file.md
+```
 
 ## Important Development Notes
 
@@ -101,6 +133,7 @@ callout: <p>👋 <b>If you're ready to take your infrastructure to the next leve
 4. **Draft Content**: Set `draft: true` in front matter to hide from production
 5. **Menu Items**: Configure in `config.yaml` under `menu` section
 6. **Redirects**: Add to `netlify.toml` (e.g., `/updates/*` → `/blog/*`)
+7. **Blog Naming**: Use date-prefixed format: `YYYY-MM-DD-title.md`
 
 ## Deployment Process
 
@@ -114,8 +147,9 @@ callout: <p>👋 <b>If you're ready to take your infrastructure to the next leve
 ### Add a New Blog Post
 
 ```bash
-hugo new blog/my-post-title.md
-# Edit content/blog/my-post-title.md
+# Blog posts use date-prefixed naming (YYYY-MM-DD-title.md)
+hugo new blog/$(date +%Y-%m-%d)-my-post-title.md
+# Edit content/blog/YYYY-MM-DD-my-post-title.md
 # Add banner image to static/img/blog/
 # Set draft: false when ready
 ```

--- a/content/blog/2025-09-17-fix-iam-trust-policy-errors-using-aws-sso-regional-arn.md
+++ b/content/blog/2025-09-17-fix-iam-trust-policy-errors-using-aws-sso-regional-arn.md
@@ -5,6 +5,7 @@ title: "Fix IAM Trust Policy Errors using AWS IAM Identity Center SSO Role Regio
 author: Yangci Ou
 slug: fix-iam-trust-policy-errors-with-aws-sso-regional-arn
 date: 2025-09-17
+# date_modified: 2025-09-17
 description: If your IAM trust policy isn't working with AWS IAM Identity Center SSO roles, it might be because us-east-1 does not have the region in the ARN while other regions do.
 image: /img/updates/aws-iam-identity-center-sso-trust-policies.png
 callout: <p>👋 <b>If you're ready to take your infrastructure to the next level, we're here to help. We love to work together with engineering teams to help them build well-documented, scalable, automated IaC that make their jobs easier. <a href='/contact'>Get in touch!</a></p>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,12 @@
                 <div class="entry">
                     <div class="flex reverse">
                         <div class="entryContent text-center">
-                            <div class="postMeta"><span>{{ .Date.Format "1.02.2006" }}</span></div>
+                            <div class="postMeta">
+                                <span>Published: {{ .Date.Format "1.02.2006" }}</span>
+                                {{ if and .Params.date_modified (ne (.Params.date_modified | dateFormat "1.02.2006") (.Date.Format "1.02.2006")) }}
+                                <span> • Updated: {{ .Params.date_modified | dateFormat "1.02.2006" }}</span>
+                                {{ end }}
+                            </div>
                             <h1 class="postTitle">
                                 {{ if .Params.outbound }}
                                 <a href="{{ .Params.outbound }}" target="_blank">{{ .Title | safeHTML }}</a>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -171,5 +171,43 @@
       })(window,document,'script','dataLayer','GTM-NWQ5HPKT');
     </script>
     <!-- End Google Tag Manager -->
+
+    {{ if eq .Section "blog" }}
+    <!-- Structured Data for Blog Posts -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      "headline": {{ .Title | jsonify }},
+      "description": {{ .Description | jsonify }},
+      "author": {
+        "@type": "Person",
+        "name": {{ if .Params.author }}{{ .Params.author | jsonify }}{{ else }}"Masterpoint"{{ end }}
+      },
+      "publisher": {
+        "@type": "Organization",
+        "name": "Masterpoint Consulting",
+        "url": "{{ .Site.BaseURL }}"
+      },
+      "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
+      {{ if .Params.date_modified }}
+      "dateModified": {{ .Params.date_modified | dateFormat "2006-01-02T15:04:05Z07:00" | jsonify }},
+      {{ else }}
+      "dateModified": {{ .Date.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
+      {{ end }}
+      "url": {{ .Permalink | jsonify }},
+      {{ if .Params.image }}
+      "image": {
+        "@type": "ImageObject",
+        "url": {{ (printf "%s%s" .Site.BaseURL .Params.image) | jsonify }}
+      },
+      {{ end }}
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": {{ .Permalink | jsonify }}
+      }
+    }
+    </script>
+    {{ end }}
   </head>
 </html>

--- a/layouts/partials/news-entry.html
+++ b/layouts/partials/news-entry.html
@@ -23,7 +23,12 @@
             </div>
             {{end}}
             <div class="entryContent">
-                <div class="postMeta"><span>{{ .Date.Format "1.02.2006" }}</span></div>
+                <div class="postMeta">
+                    <span>Published: {{ .Date.Format "1.02.2006" }}</span>
+                    {{ if and .Params.date_modified (ne (.Params.date_modified | dateFormat "1.02.2006") (.Date.Format "1.02.2006")) }}
+                    <span> • Updated: {{ .Params.date_modified | dateFormat "1.02.2006" }}</span>
+                    {{ end }}
+                </div>
                 <h3 class="postTitle">
                     {{ if .Params.outbound }}
                     <a href="{{ .Params.outbound }}" target="_blank">{{ .Title | safeHTML }}</a>


### PR DESCRIPTION
 ## Summary
* Adds support for showing when blog posts were last updated, both in the UI and for search engines via structured data.
  * If never updated, it won't show that field.
* This is in preparation of me wanting to update the TF Backend blog post to reflect the updates of DynamoDB and S3 native locking
* Additional benefit: SEO
  * Search engines likes to serve more up to date, hence more recent, content. This last modified date will indicate to search engines that our content is kept up to date when we do update it.
  * Added JSON-LD which search engines uses to understand when it was last updated. We do not need to maintain this because it'll never change and only includes foundational info like author and dates.
  * https://developers.google.com/search/docs/appearance/structured-data/article
* Update CLAUDE.md 


Example of the `/blog` index and also individually
<img width="1844" height="1535" alt="image" src="https://github.com/user-attachments/assets/f18e76ca-7b9f-48d3-893c-fb4ec840b3fd" />
<img width="2257" height="1103" alt="image" src="https://github.com/user-attachments/assets/b5675993-7868-46b5-b595-1b1f1b8c23b8" />

