### PR TITLE
feat(seo): add article date meta tags for blog posts

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,7 +6,21 @@
       name="viewport"
       content="width=device-width, initial-scale=1, minimum-scale=1"
     />
+    {{ if eq .Section "blog" }}
+    <meta property="og:type" content="article" />
+    <meta
+      property="article:published_time"
+      content="{{ .Date.Format `2006-01-02T15:04:05Z07:00` }}"
+    />
+    {{ if .Params.date_modified }}
+    <meta
+      property="article:modified_time"
+      content="{{ .Params.date_modified | dateFormat `2006-01-02T15:04:05Z07:00` }}"
+    />
+    {{ end }}
+    {{ else }}
     <meta property="og:type" content="website" />
+    {{ end }}
 
     <!-- <title> can be separated from metatitle
         <title>{{ .Title | plainify }} | {{ .Site.Title }}</title>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,8 +17,7 @@
       property="article:modified_time"
       content="{{ .Params.date_modified | dateFormat `2006-01-02T15:04:05Z07:00` }}"
     />
-    {{ end }}
-    {{ else }}
+    {{ end }} {{ else }}
     <meta property="og:type" content="website" />
     {{ end }}
 
@@ -138,11 +137,11 @@
     ></script>
 
     <link
-  rel="stylesheet"
-  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-  crossorigin="anonymous"
-  referrerpolicy="no-referrer"
-/>
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
 
     <link rel="stylesheet" href="https://use.typekit.net/noi8hrw.css" />
 
@@ -196,38 +195,38 @@
     {{ if eq .Section "blog" }}
     <!-- Structured Data for Blog Posts -->
     <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "BlogPosting",
-      "headline": {{ .Title | jsonify }},
-      "description": {{ .Description | jsonify }},
-      "author": {
-        "@type": "Person",
-        "name": {{ if .Params.author }}{{ .Params.author | jsonify }}{{ else }}"Masterpoint"{{ end }}
-      },
-      "publisher": {
-        "@type": "Organization",
-        "name": "Masterpoint Consulting",
-        "url": "{{ .Site.BaseURL }}"
-      },
-      "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
-      {{ if .Params.date_modified }}
-      "dateModified": {{ .Params.date_modified | dateFormat "2006-01-02T15:04:05Z07:00" | jsonify }},
-      {{ else }}
-      "dateModified": {{ .Date.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
-      {{ end }}
-      "url": {{ .Permalink | jsonify }},
-      {{ if .Params.image }}
-      "image": {
-        "@type": "ImageObject",
-        "url": {{ (printf "%s%s" .Site.BaseURL .Params.image) | jsonify }}
-      },
-      {{ end }}
-      "mainEntityOfPage": {
-        "@type": "WebPage",
-        "@id": {{ .Permalink | jsonify }}
+      {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": {{ .Title | jsonify }},
+        "description": {{ .Description | jsonify }},
+        "author": {
+          "@type": "Person",
+          "name": {{ if .Params.author }}{{ .Params.author | jsonify }}{{ else }}"Masterpoint"{{ end }}
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Masterpoint Consulting",
+          "url": "{{ .Site.BaseURL }}"
+        },
+        "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
+        {{ if .Params.date_modified }}
+        "dateModified": {{ .Params.date_modified | dateFormat "2006-01-02T15:04:05Z07:00" | jsonify }},
+        {{ else }}
+        "dateModified": {{ .Date.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
+        {{ end }}
+        "url": {{ .Permalink | jsonify }},
+        {{ if .Params.image }}
+        "image": {
+          "@type": "ImageObject",
+          "url": {{ (printf "%s%s" .Site.BaseURL .Params.image) | jsonify }}
+        },
+        {{ end }}
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": {{ .Permalink | jsonify }}
+        }
       }
-    }
     </script>
     {{ end }}
   </head>


### PR DESCRIPTION
- Emits `og:type=article`, `article:published_time`, and `article:modified_time` meta tags on blog posts, reinforcing the publish/updated dates already in our JSON-LD.
- Gives Google consistent date signals across both formats, making posts eligible to display the **last updated** date in search results (improves perceived freshness).

For example, this article was updated, so it should update on SEO to show that it's better up to date: 
<img width="1312" height="924" alt="image" src="https://github.com/user-attachments/assets/d777420b-2a0a-44bb-9180-d8fd4a61ffc8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Open Graph metadata handling with section-specific tags for improved social sharing
  * Blog articles now include published and optional modified date information in meta tags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->