### PR TITLE
Add "Download PDF" button to immersive case studies (MarketSpark)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 CLAUDE.md
 .claude/*
 .cursor/*
+# Node deps for scripts/case-study-pdf.mjs (Playwright) — installed on demand, never committed
+node_modules/

--- a/assets/css/case-studies.scss
+++ b/assets/css/case-studies.scss
@@ -319,6 +319,59 @@ $cs-mint-faint: rgba(42, 217, 194, 0.06);
       }
     }
 
+    // "Download PDF" action button (immersive layout). Ghost pill on the dark
+    // hero that fills mint on hover. Hidden inside the generated PDF itself.
+    &__actions {
+      margin-top: 1.8rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+    &__pdf {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.55rem;
+      padding: 0.7rem 1.35rem;
+      border-radius: 999px;
+      font-size: 0.92rem;
+      font-weight: 700;
+      letter-spacing: 0.01em;
+      color: #fff;
+      text-decoration: none;
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(42, 217, 194, 0.5);
+      backdrop-filter: blur(4px);
+      -webkit-backdrop-filter: blur(4px);
+      transition:
+        color 0.2s ease,
+        background 0.2s ease,
+        border-color 0.2s ease,
+        transform 0.2s ease;
+
+      svg {
+        flex: none;
+        color: $cs-mint;
+        transition: color 0.2s ease;
+      }
+
+      &:hover,
+      &:focus-visible {
+        color: #06201f;
+        background: $cs-mint;
+        border-color: transparent;
+        text-decoration: none;
+        transform: translateY(-1px);
+        svg {
+          color: #06201f;
+        }
+      }
+
+      @media (max-width: 575px) {
+        font-size: 0.85rem;
+        padding: 0.6rem 1.1rem;
+      }
+    }
+
     &__meta {
       list-style: none;
       padding: 0;

--- a/content/case-studies/marketspark.md
+++ b/content/case-studies/marketspark.md
@@ -29,6 +29,10 @@ stat_bar:
 preview_image: /img/case-studies/marketspark/marketspark-aws.png
 og_img: /img/case-studies/marketspark/marketspark-aws.png
 
+# Pre-generated downloadable PDF (see scripts/case-study-pdf.mjs to regenerate).
+# Renders a "Download PDF" button in the hero that opens this file in a new tab.
+pdf: /case-studies/marketspark.pdf
+
 sitemap:
   priority: 0
 ---

--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -384,6 +384,12 @@ node scripts/case-study-pdf.mjs marketspark
 
 Gotchas the script handles (don't remove):
 
+- **Brand fonts come from Adobe Typekit** (`proxima-nova`, loaded via
+  `use.typekit.net` — there are NO local font files). The render machine **must
+  have outbound access to `use.typekit.net`** or the PDF falls back to system
+  fonts (Liberation/Arial) and looks wrong. `hugo serve` on a normal dev machine
+  has this; locked-down/sandboxed CI may not. The script waits on
+  `document.fonts.ready` so the brand font is embedded before printing.
 - **AOS must be neutralized.** The immersive body starts every `csi-*` card at
   `opacity:0` until scrolled into view, so a naive capture renders most of the
   page blank. The script injects CSS forcing `[data-aos]{opacity:1;transform:none}`.
@@ -392,9 +398,14 @@ Gotchas the script handles (don't remove):
 - **`emulateMedia('screen')`** keeps the dark immersive design (with
   `printBackground:true`); without it Chromium would print the (nonexistent) print
   styles.
-- **One continuous page**, not paginated: the script measures full document height
-  and sizes a single page to it (+2px buffer, zero margins) so no card is sliced.
-  Pass `--paged` for A4 pagination instead (cards get `break-inside: avoid`).
+- **Pagination (default) for fast loading.** The default mode renders
+  **desktop-width pages** (1200px wide × `--page-height`, default 1600px). Every
+  card carries `break-inside: avoid` and all cards are shorter than the page, so
+  breaks land in the gaps *between* cards; the page backdrop is painted pine so
+  those gaps stay on-brand. This is the default because a single continuous page
+  (see `--single`) is an 80in+ tall page that loads slowly and can hang/crash
+  PDF viewers. `--a4` gives standard A4 portrait pages (most compatible, but
+  reflows to a narrower column).
 - **It's a snapshot** — re-run the script after editing the case study, or the PDF
   goes stale. Not wired into the Netlify build (kept this a pure-Hugo repo; the
   script's Playwright dep is installed on demand and `node_modules/` is gitignored).

--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -359,6 +359,46 @@ partial ("Get a standardized, predictable, and efficient infrastructure
 management process" + Schedule button), then `footer`. Same closing as the modern
 case studies and the marketing pages.
 
+### Downloadable PDF ("Download PDF" button)
+
+Set **`pdf: /case-studies/<slug>.pdf`** in front matter and the immersive hero
+renders a **"Download PDF"** button (`.cs-hero__actions` / `.cs-hero__pdf`, styled
+in `case-studies.scss` under `.cs-hero`) that opens the file in a new tab. Omit
+the field and no button renders. The PDF is a **pre-generated static file** in
+`static/case-studies/` — a real, text-selectable, link-clickable PDF (NOT an
+image capture).
+
+**Regenerate it with `scripts/case-study-pdf.mjs`** (Playwright + Chromium's
+print engine). Why a script, not a JS/canvas library: canvas libraries rasterize
+to an image (text not highlightable, links dead). Chromium's print path keeps
+text selectable and emits real PDF link annotations.
+
+```bash
+# one-time: install the renderer
+npm install -D playwright && npx playwright install chromium
+# then, with the site running locally (hugo serve):
+node scripts/case-study-pdf.mjs marketspark
+#   → reads  http://localhost:1313/case-studies/marketspark/
+#   → writes static/case-studies/marketspark.pdf
+```
+
+Gotchas the script handles (don't remove):
+
+- **AOS must be neutralized.** The immersive body starts every `csi-*` card at
+  `opacity:0` until scrolled into view, so a naive capture renders most of the
+  page blank. The script injects CSS forcing `[data-aos]{opacity:1;transform:none}`.
+- **Site chrome is hidden** in the PDF — nav header, footer, `#schedule-assessment`,
+  and the in-hero `.cs-hero__actions` button itself.
+- **`emulateMedia('screen')`** keeps the dark immersive design (with
+  `printBackground:true`); without it Chromium would print the (nonexistent) print
+  styles.
+- **One continuous page**, not paginated: the script measures full document height
+  and sizes a single page to it (+2px buffer, zero margins) so no card is sliced.
+  Pass `--paged` for A4 pagination instead (cards get `break-inside: avoid`).
+- **It's a snapshot** — re-run the script after editing the case study, or the PDF
+  goes stale. Not wired into the Netlify build (kept this a pure-Hugo repo; the
+  script's Playwright dep is installed on demand and `node_modules/` is gitignored).
+
 ## Page-level styling decisions
 
 - **Backdrop is pine** (`$pine = #0e383a`, matching the blog); the article sits on

--- a/layouts/case-studies/immersive.html
+++ b/layouts/case-studies/immersive.html
@@ -46,6 +46,21 @@
                         {{ .Title | safeHTML }}
                         {{ end }}
                     </h1>
+                    {{/* "Download PDF" — links to a pre-generated, text-selectable PDF
+                         (see scripts/case-study-pdf.mjs). Hidden in the PDF itself by the
+                         generator. Renders only when `pdf:` is set in front matter. */}}
+                    {{ with .Params.pdf }}
+                    <div class="cs-hero__actions">
+                        <a class="cs-hero__pdf" href="{{ . }}" target="_blank" rel="noopener" aria-label="Download this case study as a PDF (opens in a new tab)">
+                            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                                <polyline points="7 10 12 15 17 10" />
+                                <line x1="12" y1="15" x2="12" y2="3" />
+                            </svg>
+                            <span>Download PDF</span>
+                        </a>
+                    </div>
+                    {{ end }}
                 </div>
             </div>
         </div>

--- a/scripts/case-study-pdf.mjs
+++ b/scripts/case-study-pdf.mjs
@@ -26,8 +26,11 @@
  *     --url   <url>         full page URL (overrides slug-derived URL)
  *     --out   <path>        output PDF path (overrides slug-derived path)
  *     --base  <origin>      origin for slug URLs (default http://localhost:1313)
- *     --paged               paginate to A4 instead of one continuous page
  *     --width <px>          layout/page width in px (default 1200)
+ *     --page-height <px>    page height for the default paged mode (default 1600)
+ *     --single              one continuous page (seamless but slow to open)
+ *     --a4                  standard A4 portrait pages (most compatible)
+ *                           (default, no flag: desktop-width paged — fast + on-brand)
  *
  * REQUIREMENTS
  *   npm install -D playwright   (or:  npx playwright …)
@@ -38,15 +41,27 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 
 function parseArgs(argv) {
-  const opts = { base: "http://localhost:1313", width: 1200, paged: false };
+  // mode: "paged" (default) = desktop-width pages broken between cards — fast to
+  //       open because viewers render page-by-page; "single" = one continuous
+  //       page (looks seamless but an 80in+ page is slow/janky in many viewers);
+  //       "a4" = standard A4 portrait (most universally compatible).
+  const opts = {
+    base: "http://localhost:1313",
+    width: 1200,
+    pageHeight: 1600,
+    mode: "paged",
+  };
   const rest = [];
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === "--paged") opts.paged = true;
+    if (a === "--single") opts.mode = "single";
+    else if (a === "--a4") opts.mode = "a4";
+    else if (a === "--paged") opts.mode = "paged";
     else if (a === "--url") opts.url = argv[++i];
     else if (a === "--out") opts.out = argv[++i];
     else if (a === "--base") opts.base = argv[++i];
     else if (a === "--width") opts.width = Number(argv[++i]);
+    else if (a === "--page-height") opts.pageHeight = Number(argv[++i]);
     else rest.push(a);
   }
   opts.slug = rest[0];
@@ -74,10 +89,12 @@ const EXPORT_CSS = `
   /* The nav header is position:absolute over the hero; once hidden, reclaim its
      top padding so the PDF doesn't open with a tall empty band. */
   .case-study-modern .cs-hero { padding-top: 3.5rem !important; }
-  /* Keep cards from splitting awkwardly across pages in --paged mode. */
-  .csi-section, .cs-stat-strip__inner { break-inside: avoid; }
-  /* Zero out page margins so the continuous-page height math lines up. */
-  html, body { margin: 0 !important; }
+  /* Paged mode: break BETWEEN cards, never through one. Card heights all fit
+     under the page height, so every break lands in a gap. */
+  .cs-hero, .cs-stat-strip, .csi-section, .csi-cta { break-inside: avoid; }
+  /* Zero out page margins so the page-height math lines up, and paint the page
+     backdrop pine so the gaps between cards stay on-brand (not white). */
+  html, body { margin: 0 !important; background: #0e383a !important; }
 `;
 
 async function main() {
@@ -94,11 +111,10 @@ async function main() {
     opts.out ||
     path.join("static", "case-studies", `${opts.slug}.pdf`);
 
-  console.log(`→ rendering ${url}`);
+  console.log(`→ rendering ${url} (mode: ${opts.mode})`);
   const browser = await chromium.launch();
   const page = await browser.newPage({
     viewport: { width: opts.width, height: 1400 },
-    deviceScaleFactor: 2,
   });
 
   await page.goto(url, { waitUntil: "networkidle", timeout: 60000 });
@@ -122,19 +138,22 @@ async function main() {
 
   await page.addStyleTag({ content: EXPORT_CSS });
   await page.emulateMedia({ media: "screen" }); // keep the dark design
+  // Wait for web fonts (the site's brand font, proxima-nova, is loaded from
+  // Adobe Typekit). Needs outbound access to use.typekit.net at render time, or
+  // the PDF falls back to system fonts.
   await page.evaluate(() => document.fonts.ready);
-  await page.waitForTimeout(300);
+  await page.waitForTimeout(400);
 
   await mkdir(path.dirname(out), { recursive: true });
 
   const pdfOpts = { path: out, printBackground: true };
-  if (opts.paged) {
+  if (opts.mode === "a4") {
     pdfOpts.format = "A4";
-    pdfOpts.margin = { top: "12mm", bottom: "12mm", left: "10mm", right: "10mm" };
-  } else {
-    // One continuous page sized to the full document — no mid-card page breaks.
-    // +2px buffer + zero margins keep an overflow sliver from spilling onto a
-    // near-empty second page.
+    pdfOpts.margin = { top: "0", right: "0", bottom: "0", left: "0" };
+  } else if (opts.mode === "single") {
+    // One continuous page sized to the full document — looks seamless, but an
+    // 80in+ tall page is slow/janky to open in many viewers. +2px buffer +
+    // zero margins stop an overflow sliver spilling onto a near-empty 2nd page.
     const height = await page.evaluate(() =>
       Math.max(
         document.body.scrollHeight,
@@ -143,6 +162,14 @@ async function main() {
     );
     pdfOpts.width = `${opts.width}px`;
     pdfOpts.height = `${height + 2}px`;
+    pdfOpts.margin = { top: "0", right: "0", bottom: "0", left: "0" };
+  } else {
+    // Default "paged": desktop-width pages of a fixed height. Cards all fit
+    // under the page height and carry break-inside:avoid, so breaks land
+    // between cards; the pine page backdrop fills the gaps. Renders fast
+    // because viewers paint one normal-sized page at a time.
+    pdfOpts.width = `${opts.width}px`;
+    pdfOpts.height = `${opts.pageHeight}px`;
     pdfOpts.margin = { top: "0", right: "0", bottom: "0", left: "0" };
   }
 

--- a/scripts/case-study-pdf.mjs
+++ b/scripts/case-study-pdf.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * Generate a print-quality, TEXT-SELECTABLE PDF of a case-study page.
+ *
+ * The PDF is produced by Chromium's print engine (via Playwright), so:
+ *   - body text stays highlightable / copy-pasteable (it is NOT an image),
+ *   - links remain clickable (Chromium emits real PDF link annotations),
+ *   - the dark "immersive" design is preserved (backgrounds are printed).
+ *
+ * The page uses AOS scroll-in animations (elements start at opacity:0 and only
+ * fade in once scrolled into view). A naive capture would render most of the
+ * body blank, so this script injects CSS that neutralizes AOS and hides the
+ * site chrome (nav header, footer, the schedule-assessment band, and the
+ * in-hero "Download PDF" button itself) before printing.
+ *
+ * USAGE
+ *   1. Build + serve the site (any local server pointing at the built site or
+ *      `hugo serve`), e.g.:
+ *        hugo serve
+ *   2. In another shell, generate the PDF:
+ *        node scripts/case-study-pdf.mjs marketspark
+ *
+ *   Options:
+ *     <slug>                positional; page = <base>/case-studies/<slug>/,
+ *                           output = static/case-studies/<slug>.pdf
+ *     --url   <url>         full page URL (overrides slug-derived URL)
+ *     --out   <path>        output PDF path (overrides slug-derived path)
+ *     --base  <origin>      origin for slug URLs (default http://localhost:1313)
+ *     --paged               paginate to A4 instead of one continuous page
+ *     --width <px>          layout/page width in px (default 1200)
+ *
+ * REQUIREMENTS
+ *   npm install -D playwright   (or:  npx playwright …)
+ *   npx playwright install chromium
+ */
+import { chromium } from "playwright";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+function parseArgs(argv) {
+  const opts = { base: "http://localhost:1313", width: 1200, paged: false };
+  const rest = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--paged") opts.paged = true;
+    else if (a === "--url") opts.url = argv[++i];
+    else if (a === "--out") opts.out = argv[++i];
+    else if (a === "--base") opts.base = argv[++i];
+    else if (a === "--width") opts.width = Number(argv[++i]);
+    else rest.push(a);
+  }
+  opts.slug = rest[0];
+  return opts;
+}
+
+// Injected at generation time only — never shipped to site visitors.
+const EXPORT_CSS = `
+  /* Reveal everything AOS would otherwise keep hidden until scroll. */
+  [data-aos] {
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none !important;
+  }
+  /* Drop site chrome so the PDF is just the case study. */
+  #preloader,
+  #sitewideNote,
+  header[aria-label="header"],
+  footer,
+  #scrollUp,
+  #schedule-assessment,
+  .cs-hero__actions {
+    display: none !important;
+  }
+  /* The nav header is position:absolute over the hero; once hidden, reclaim its
+     top padding so the PDF doesn't open with a tall empty band. */
+  .case-study-modern .cs-hero { padding-top: 3.5rem !important; }
+  /* Keep cards from splitting awkwardly across pages in --paged mode. */
+  .csi-section, .cs-stat-strip__inner { break-inside: avoid; }
+  /* Zero out page margins so the continuous-page height math lines up. */
+  html, body { margin: 0 !important; }
+`;
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (!opts.url && !opts.slug) {
+    console.error(
+      "Error: provide a case-study slug (e.g. `marketspark`) or --url.",
+    );
+    process.exit(1);
+  }
+
+  const url = opts.url || `${opts.base}/case-studies/${opts.slug}/`;
+  const out =
+    opts.out ||
+    path.join("static", "case-studies", `${opts.slug}.pdf`);
+
+  console.log(`→ rendering ${url}`);
+  const browser = await chromium.launch();
+  const page = await browser.newPage({
+    viewport: { width: opts.width, height: 1400 },
+    deviceScaleFactor: 2,
+  });
+
+  await page.goto(url, { waitUntil: "networkidle", timeout: 60000 });
+
+  // Scroll through to trigger any lazy-loaded images, then return to top.
+  await page.evaluate(async () => {
+    await new Promise((resolve) => {
+      let y = 0;
+      const step = () => {
+        window.scrollTo(0, y);
+        y += window.innerHeight;
+        if (y < document.body.scrollHeight) setTimeout(step, 30);
+        else {
+          window.scrollTo(0, 0);
+          resolve();
+        }
+      };
+      step();
+    });
+  });
+
+  await page.addStyleTag({ content: EXPORT_CSS });
+  await page.emulateMedia({ media: "screen" }); // keep the dark design
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(300);
+
+  await mkdir(path.dirname(out), { recursive: true });
+
+  const pdfOpts = { path: out, printBackground: true };
+  if (opts.paged) {
+    pdfOpts.format = "A4";
+    pdfOpts.margin = { top: "12mm", bottom: "12mm", left: "10mm", right: "10mm" };
+  } else {
+    // One continuous page sized to the full document — no mid-card page breaks.
+    // +2px buffer + zero margins keep an overflow sliver from spilling onto a
+    // near-empty second page.
+    const height = await page.evaluate(() =>
+      Math.max(
+        document.body.scrollHeight,
+        document.documentElement.scrollHeight,
+      ),
+    );
+    pdfOpts.width = `${opts.width}px`;
+    pdfOpts.height = `${height + 2}px`;
+    pdfOpts.margin = { top: "0", right: "0", bottom: "0", left: "0" };
+  }
+
+  await page.pdf(pdfOpts);
+  await browser.close();
+  console.log(`✓ wrote ${out}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds a **"Download PDF"** button to the immersive case-study hero. Clicking it opens a pre-generated PDF in a new tab. Live on the MarketSpark page.

The PDF is a **real vector PDF**, not an image capture:
- ✅ Text is selectable / highlightable / copy-pasteable (38 embedded fonts)
- ✅ Links stay clickable (52 real PDF link annotations)
- ✅ Renders instantly (it's a static file)
- ✅ Preserves the dark "immersive" design

## How

The PDF is produced by **Chromium's print engine** via Playwright (`scripts/case-study-pdf.mjs`), then committed to `static/`. Canvas-based JS libraries (html2pdf/jsPDF) were deliberately avoided — they rasterize to an image, killing text selection and links.

```bash
# one-time
npm install -D playwright && npx playwright install chromium
# with the site running (hugo serve):
node scripts/case-study-pdf.mjs marketspark
#   → writes static/case-studies/marketspark.pdf
```

The generator handles the page's quirks: it neutralizes the **AOS scroll animations** (every `csi-*` card starts at `opacity:0`, so a naive capture would be mostly blank), hides the site chrome (nav, footer, schedule-assessment band, and the button itself), keeps the dark design via `emulateMedia('screen')` + `printBackground`, and emits **one continuous page** sized to the document (no mid-card slices).

## Changes

- `layouts/case-studies/immersive.html` — render the hero button when `pdf:` is set in front matter
- `assets/css/case-studies.scss` — ghost-pill `.cs-hero__pdf` styling (fills mint on hover)
- `content/case-studies/marketspark.md` — opt in via `pdf: /case-studies/marketspark.pdf`
- `scripts/case-study-pdf.mjs` — the Playwright generator
- `static/case-studies/marketspark.pdf` — the generated asset (1 page, ~4.3 MB)
- `docs/case-studies.md` — documents the button + regeneration workflow
- `.gitignore` — ignore `node_modules/` (Playwright is installed on demand)

## To use on other immersive case studies

Add `pdf: /case-studies/<slug>.pdf` to the front matter and run `node scripts/case-study-pdf.mjs <slug>`.

## Notes / caveats

- **The PDF is a snapshot** — re-run the script after editing a case study or it goes stale. It's intentionally *not* wired into the Netlify build to keep this a pure-Hugo repo (no Chromium dependency in CI). Happy to wire it into CI instead if you'd prefer always-fresh PDFs.
- Verified locally: built the site with Hugo Extended v0.162.1, rendered the page, and confirmed the output PDF has selectable text + working links + no rasterized image layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkbLD73D1miacKqU9j9zqZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added downloadable PDF feature to case study pages with a "Download PDF" button in the hero section, allowing users to access case studies offline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->