### PR TITLE
fix(rss): base URL

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseURL:
+baseURL: https://masterpoint.io/
 locale: en-us
 title: Masterpoint Consulting
 taxonomies:


### PR DESCRIPTION
# see before & after, the `baseURL` is empty
<img width="1513" height="1783" alt="image" src="https://github.com/user-attachments/assets/b16274ca-bead-4cdb-98e7-f66701ef9965" />
<img width="1512" height="1784" alt="image" src="https://github.com/user-attachments/assets/15738370-4932-478e-a9bf-77911125ab7b" />
<img width="1016" height="500" alt="image" src="https://github.com/user-attachments/assets/dfac5412-0675-4615-9215-609e7ac8374c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base URL configuration to ensure proper absolute URL generation across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->