### PR TITLE
[wip demo testing] feat(home): add featured case-study slider with metrics and logo tabs

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -4187,4 +4187,460 @@ font-size: 1.55rem;
   }
 }
 
+// ---------------------------------------------------------------------------
+// HOME — CASE STUDY HIGHLIGHTS SLIDER (#case-study-highlights, .csh-*)
+// Featured case-study cards on a sliding track, navigated by a client-logo
+// tab strip with an autoplay progress bar. Markup lives in
+// layouts/shortcodes/case-study-slider.html; see docs/case-studies.md.
+// ---------------------------------------------------------------------------
+.csh {
+  margin-top: 2.6rem;
+
+  &__viewport {
+    overflow: hidden;
+    border-radius: 24px;
+    box-shadow: 0 24px 48px -28px rgba(14, 56, 58, 0.45);
+  }
+  &__track {
+    display: flex;
+    transition: transform 0.65s cubic-bezier(0.33, 0, 0.15, 1);
+    will-change: transform;
+  }
+}
+
+.csh-slide {
+  flex: 0 0 100%;
+  min-width: 100%;
+  // Keep off-screen slides out of the accessibility tree / paint until they
+  // slide in: hide only after the track transition has finished.
+  visibility: hidden;
+  transition: visibility 0s 0.65s;
+  &.is-active {
+    visibility: visible;
+    transition-delay: 0s;
+  }
+}
+
+.csh-card {
+  display: flex;
+  height: 100%;
+  min-height: 460px;
+  position: relative;
+  overflow: hidden;
+  border-radius: 24px;
+  background: linear-gradient(135deg, #0e383a 0%, #0a2a2c 55%, #061d1e 100%);
+  color: #fff;
+
+  // soft mint / pink glows (echoes the case-study hero)
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+      radial-gradient(ellipse at 85% 15%, rgba(42, 217, 194, 0.16), transparent 55%),
+      radial-gradient(ellipse at 8% 92%, rgba(216, 145, 206, 0.12), transparent 50%);
+    pointer-events: none;
+  }
+  // faint dot grid, fading downward
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+    background-size: 28px 28px;
+    mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.7), transparent 80%);
+    -webkit-mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.7), transparent 80%);
+    pointer-events: none;
+  }
+
+  &__topline {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    z-index: 2;
+    background: linear-gradient(92deg, #ede497 -0.66%, #2ad9c2 26%, #d891ce 59.55%);
+  }
+
+  &__body {
+    position: relative;
+    z-index: 1;
+    flex: 1 1 55%;
+    min-width: 0;
+    padding: 3rem 3rem 2.8rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  &__logo {
+    background: #fff;
+    border-radius: 10px;
+    padding: 0.6rem 0.95rem;
+    margin-bottom: 1.6rem;
+    box-shadow: 0 8px 18px -10px rgba(0, 0, 0, 0.5);
+    img {
+      display: block;
+      height: 26px;
+      width: auto;
+    }
+  }
+
+  &__eyebrow {
+    color: #2ad9c2;
+    text-transform: uppercase;
+    font-weight: 700;
+    font-size: 0.8rem;
+    letter-spacing: 0.14em;
+    margin-bottom: 0.8rem;
+  }
+
+  &__title {
+    font-size: 1.85rem;
+    font-weight: 800;
+    line-height: 1.22em;
+    color: #fff;
+    margin-bottom: 0.9rem;
+    max-width: 36rem;
+  }
+
+  &__blurb {
+    color: rgba(255, 255, 255, 0.82);
+    font-size: 1rem;
+    line-height: 1.55em;
+    margin-bottom: 1.7rem;
+    max-width: 34rem;
+  }
+
+  &__stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.4rem 2rem;
+    align-items: start;
+    width: 100%;
+    max-width: 34rem;
+    margin-bottom: 2rem;
+  }
+
+  &__cta {
+    margin-top: auto;
+  }
+
+  &__media {
+    flex: 1 1 45%;
+    position: relative;
+    min-height: 300px;
+    img {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    // blend the photo into the pine card
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(90deg, rgba(10, 42, 44, 0.55) 0%, rgba(10, 42, 44, 0) 35%);
+      pointer-events: none;
+    }
+  }
+}
+
+.csh-stat {
+  &__value {
+    @extend .text-gradient;
+    font-size: 2.3rem;
+    font-weight: 800;
+    line-height: 1em;
+    white-space: nowrap;
+  }
+  &__label {
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 0.95rem;
+    line-height: 1.35em;
+    max-width: 15rem;
+    padding-top: 0.45em;
+  }
+}
+
+.csh-nav {
+  display: flex;
+  align-items: center;
+  // centered on the outer row; the inner __tabs group scrolls when it
+  // overflows (centering the scroll container itself would clip its left end)
+  justify-content: center;
+  gap: 0.9rem;
+  margin-top: 1.6rem;
+  min-width: 0;
+
+  &__tabs {
+    display: flex;
+    gap: 1rem;
+    min-width: 0;
+    overflow-x: auto;
+    padding: 0.25rem 0.25rem 0.45rem;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  // persistent autoplay pause/play control (WCAG 2.2.2)
+  &__toggle {
+    flex: 0 0 auto;
+    appearance: none;
+    -webkit-appearance: none;
+    width: 46px;
+    height: 46px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #fff;
+    border: 1px solid #dfe7e7;
+    border-radius: 50%;
+    cursor: pointer;
+    transition:
+      border-color 0.25s,
+      box-shadow 0.25s;
+    svg {
+      display: block;
+      width: 13px;
+      height: 13px;
+      fill: #0e383a;
+    }
+    .csh-nav__icon-play {
+      display: none;
+    }
+    &:hover,
+    &:focus-visible {
+      border-color: #2ad9c2;
+    }
+    &:focus-visible {
+      outline: 2px solid #2ad9c2;
+      outline-offset: 2px;
+    }
+  }
+
+  // text fallback when a case study has no logo for the tab strip
+  &__name {
+    display: block;
+    font-weight: 700;
+    font-size: 1rem;
+    line-height: 30px;
+    color: #0e383a;
+    white-space: nowrap;
+  }
+
+  &__tab {
+    flex: 0 0 auto;
+    appearance: none;
+    -webkit-appearance: none;
+    background: #fff;
+    border: 1px solid #dfe7e7;
+    border-radius: 14px;
+    padding: 1.05rem 2.2rem 1.2rem;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+    transition:
+      border-color 0.25s,
+      box-shadow 0.25s;
+
+    img {
+      display: block;
+      height: 30px;
+      width: auto;
+      filter: grayscale(1);
+      opacity: 0.5;
+      transition:
+        filter 0.25s,
+        opacity 0.25s;
+    }
+    &:hover,
+    &:focus-visible {
+      border-color: #b9cdcd;
+      img {
+        filter: none;
+        opacity: 1;
+      }
+    }
+    &:focus-visible {
+      outline: 2px solid #2ad9c2;
+      outline-offset: 2px;
+    }
+    &.is-active {
+      border-color: rgba(42, 217, 194, 0.5);
+      box-shadow: 0 12px 24px -14px rgba(14, 56, 58, 0.4);
+      img {
+        filter: none;
+        opacity: 1;
+      }
+    }
+  }
+
+  &__bar {
+    display: block;
+    position: absolute;
+    // inset 1px so the bar hugs the inside of the tab border and its rounded
+    // corners instead of notching past them
+    left: 1px;
+    right: 1px;
+    bottom: 1px;
+    height: 4px;
+    border-radius: 0 0 13px 13px;
+    overflow: hidden;
+    background: rgba(14, 56, 58, 0.08);
+  }
+  &__progress {
+    display: block;
+    height: 100%;
+    // full-width gradient revealed by the clip-path animation, so the colors
+    // stay put while the bar fills (a width animation would stretch them)
+    width: 100%;
+    background: linear-gradient(92deg, #ede497 -0.66%, #2ad9c2 26%, #d891ce 59.55%);
+    clip-path: inset(0 100% 0 0);
+  }
+}
+
+// Autoplay: the active tab's bar fills over 8s (only while the slider is on
+// screen); the shortcode JS advances on animationend and toggles the classes.
+// The paused/stopped rules must match the run rule's specificity and come
+// AFTER it — the `animation` shorthand resets animation-play-state to
+// `running`, so a lower-specificity pause rule would silently lose.
+.csh.csh--inview .csh-nav__tab.is-active .csh-nav__progress {
+  animation: cshProgress 8s linear forwards;
+}
+.csh.csh--paused .csh-nav__tab.is-active .csh-nav__progress {
+  animation-play-state: paused;
+}
+.csh.csh--stopped .csh-nav__tab.is-active .csh-nav__progress {
+  animation: none;
+}
+.csh.csh--stopped .csh-nav__toggle {
+  .csh-nav__icon-pause {
+    display: none;
+  }
+  .csh-nav__icon-play {
+    display: block;
+  }
+}
+@keyframes cshProgress {
+  from {
+    clip-path: inset(0 100% 0 0);
+  }
+  to {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+.csh-see-all {
+  margin-top: 2.4rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .csh__track {
+    transition: none;
+  }
+  .csh-slide {
+    transition: none;
+  }
+  .csh .csh-nav__progress {
+    animation: none !important;
+  }
+}
+
+@media (max-width: 991px) {
+  .csh-card {
+    // media (last child) on top, text below — mirrors the list-page cards
+    flex-direction: column-reverse;
+    min-height: 0;
+
+    &__body {
+      padding: 2.2rem 1.7rem 2rem;
+    }
+    &__title {
+      font-size: 1.45rem;
+    }
+    &__media {
+      flex: 0 0 auto;
+      width: 100%;
+      min-height: 0;
+      height: 240px;
+      &::after {
+        background: linear-gradient(0deg, rgba(10, 42, 44, 0.55) 0%, rgba(10, 42, 44, 0) 40%);
+      }
+    }
+  }
+  .csh-stat {
+    &__value {
+      font-size: 2rem;
+    }
+    &__label {
+      font-size: 0.9rem;
+    }
+  }
+  .csh-nav__toggle {
+    width: 40px;
+    height: 40px;
+  }
+  .csh-nav__tab {
+    padding: 0.85rem 1.5rem 1rem;
+    border-radius: 12px;
+    img {
+      height: 24px;
+    }
+  }
+  .csh-nav__name {
+    line-height: 24px;
+    font-size: 0.95rem;
+  }
+}
+
+@media (max-width: 575px) {
+  .csh {
+    margin-top: 1.8rem;
+  }
+  .csh__viewport {
+    border-radius: 18px;
+  }
+  .csh-card {
+    border-radius: 18px;
+    &__body {
+      padding: 1.9rem 1.3rem 1.8rem;
+    }
+    // single column so wide values ("0% → 100%") never clip
+    &__stats {
+      grid-template-columns: 1fr;
+      gap: 1.1rem;
+    }
+    &__media {
+      height: 200px;
+    }
+  }
+  // tighten the control strip so toggle + both tabs fit a small phone
+  .csh-nav {
+    gap: 0.6rem;
+  }
+  .csh-nav__tabs {
+    gap: 0.6rem;
+  }
+  .csh-nav__toggle {
+    width: 36px;
+    height: 36px;
+  }
+  .csh-nav__tab {
+    padding: 0.7rem 1.1rem 0.85rem;
+    img {
+      height: 22px;
+    }
+  }
+  .csh-nav__name {
+    line-height: 22px;
+    font-size: 0.9rem;
+  }
+}
+
 @import "case-studies.scss";

--- a/content/case-studies/marketspark.md
+++ b/content/case-studies/marketspark.md
@@ -29,6 +29,20 @@ stat_bar:
 preview_image: /img/case-studies/marketspark/marketspark-aws.png
 og_img: /img/case-studies/marketspark/marketspark-aws.png
 
+# Homepage highlight card (see docs/case-studies.md → Homepage slider)
+highlight:
+  eyebrow: "AWS · Infrastructure as Code"
+  title: "MarketSpark's cloud, rebuilt as a <span class='text-gradient'>100% IaC multi-account platform</span>"
+  blurb: "Masterpoint rebuilt MarketSpark's single manually-operated AWS account into an 11-account AWS Organization: fully codified, automated, and ready to scale."
+  image: /img/case-studies/marketspark/telecommunications.jpg
+  image_alt: "City lights glowing across Earth at night, seen from orbit"
+  logo: /img/case-studies/marketspark/marketspark-logo-dark.png
+  stats:
+    - value: "0% → 100%"
+      label: "Infrastructure as Code, automated end to end"
+    - value: "1 → 11"
+      label: "monolithic account to a full AWS Organization"
+
 sitemap:
   priority: 0
 ---

--- a/content/case-studies/power-digital.md
+++ b/content/case-studies/power-digital.md
@@ -29,6 +29,20 @@ stat_bar:
 preview_image: /img/case-studies/power-digital/power-digital-case-study-preview.jpg
 og_img: /img/case-studies/power-digital/power-digital-case-study-preview.jpg
 
+# Homepage highlight card (see docs/case-studies.md → Homepage slider)
+highlight:
+  eyebrow: "IaC Automation · Cost Optimization"
+  title: "Power Digital cut automation costs <span class='text-gradient'>10x</span> and onboards clients <span class='text-gradient'>8x faster</span>"
+  blurb: "Masterpoint migrated Power Digital's 43,000-resource Terraform monolith to Spacelift and OpenTofu, and the platform onboarded 100+ new clients in the first 60 days."
+  image: /img/case-studies/power-digital/power-digital-team.jpg
+  image_alt: "Power Digital team collaborating in their office"
+  logo: /img/case-studies/power-digital/power-digital-logo.png
+  stats:
+    - value: "10x"
+      label: "lower infrastructure automation costs"
+    - value: "25 → 3 min"
+      label: "plan & apply deployment cycles"
+
 sitemap:
   priority: 0
 

--- a/content/sections/home-case-studies.md
+++ b/content/sections/home-case-studies.md
@@ -1,0 +1,23 @@
+---
+title: Case Study Success Stories
+weight: 5
+section_categories:
+  - Home
+id: case-study-highlights
+---
+
+<div class="row justify-content-center text-center">
+<div class="col col-12 col-md-10 col-lg-8 col-xl-7">
+
+### Real Engagements, <span class="text-gradient">Real Results</span> {.groupTitle .text-center .text-rhythm}
+
+<p class="font20 text-pine">See how engineering teams partner with Masterpoint to turn tangled infrastructure into platforms that scale.</p>
+
+</div>
+</div>
+
+{{<case-study-slider>}}
+
+<div class="text-center csh-see-all">
+<a href="/case-studies/" class="button btn-outline-gradient text-pine btn-big">See All Case Studies →</a>
+</div>

--- a/content/sections/home-our-word.md
+++ b/content/sections/home-our-word.md
@@ -1,6 +1,6 @@
 ---
 title: Don't take our word for it...
-weight: 5
+weight: 6
 #position: align-items-center justify-content-end
 size: col-12 col-md-7
 #section_image: /img/doctor_and_patient.jpg

--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -77,6 +77,95 @@ card grid to stay scannable as the list grows. Card image = each study's
 
 ---
 
+## Homepage highlights slider
+
+The homepage has a featured case-study slider (section
+`content/sections/home-case-studies.md`, id `#case-study-highlights`, weight 5 —
+between "Efficient Platforms" and the testimonials). It renders one full-width
+dark pine card per case study (client logo on a white pill, category eyebrow,
+short title, blurb, **two headline metrics**, CTA, photo) on a sliding track,
+navigated by a client-logo tab strip — the Microsoft-customer-stories pattern.
+
+- **Markup + JS:** `layouts/shortcodes/case-study-slider.html` (self-contained
+  vanilla JS; no jQuery). It iterates `where site.RegularPages "Section"
+  "case-studies"` **ByWeight**, so case-study `weight:` also orders the slides.
+- **Styles:** `.csh-*` block in `assets/css/custom.scss` (directly above the
+  `case-studies.scss` import). Scoped to `.csh-`; literal hex colors since the
+  `$cs-*` vars aren't defined at that point in the cascade.
+- **Content comes from an optional `highlight:` front-matter map** on each case
+  study (see marketspark.md / power-digital.md):
+
+  ```yaml
+  highlight:
+    eyebrow: "AWS · Infrastructure as Code" # category label, mint uppercase
+    title: "... <span class='text-gradient'>...</span>" # short card title (HTML ok)
+    blurb: "One or two sentences."
+    image: /img/case-studies/CLIENT/photo.jpg # card photo (right column)
+    image_alt: "..."
+    logo: /img/case-studies/CLIENT/CLIENT-logo-dark.png # DARK logo variant — used on the white tab strip AND the white card pill
+    stats: # exactly two headline metrics
+      - value: "10x"
+        label: "lower infrastructure automation costs"
+      - value: "25 → 3 min"
+        label: "plan & apply deployment cycles"
+  ```
+
+  Every field falls back sensibly if omitted: `title` → page title, `blurb` →
+  `description`, `image` → `preview_image`, `stats` → first 2 `stat_bar`
+  entries, `logo` → `client_logo`, `eyebrow` → `Case Study · {client}`.
+  Set `highlight: false` to keep a case study out of the slider entirely. Any
+  other **non-map** value (`highlight: true`, a string, …) includes the study
+  with pure fallbacks — the template only reads fields after a `reflect.IsMap`
+  check, so a scalar can't crash the build (`$h.foo` on a bool is a fatal
+  template error; `| default dict` does NOT replace `true`).
+- **Use the dark logo variant** for `highlight.logo` — it sits on white
+  surfaces (tab strip + card pill). The hero `client_logo` may be a white
+  variant (Power Digital), which would vanish there; that's why the field
+  exists. A study with no logo at all gets its client name as a text tab
+  (`.csh-nav__name`).
+- **Slider mechanics:** custom vanilla JS in the shortcode, NOT flexslider/owl —
+  plugins.js initializes ALL `.flexslider` elements globally with dot controls,
+  which would fight the logo-tab navigation. Autoplay is driven by the active
+  tab's progress-bar CSS animation (8s, `cshProgress` keyframes): JS advances on
+  `animationend`, so pausing the animation pauses the slider exactly in sync
+  with the bar. The bar is a full-width gradient revealed via `clip-path` (a
+  width animation would stretch the colors). Touch swipe + roving-tabindex
+  arrow keys included; off-screen slides are `visibility: hidden` (delayed
+  until the track transition ends) with their links untabbable.
+- **Autoplay gating — four independent conditions, all in CSS classes:**
+  - `.csh--inview` (IntersectionObserver): on once ≥25% visible, off only when
+    fully off-screen. Gate on `intersectionRatio`, not bare `isIntersecting` —
+    that flips true at the first visible pixel regardless of `threshold`.
+  - `.csh--paused` (transient): mouse hover OR keyboard focus, tracked as two
+    separate booleans — `focusout` only clears it if focus actually left the
+    root (`relatedTarget` check), so mouse-leave can't resume rotation while
+    focus is still inside (an auto-advance would hide the focused element).
+    Hover uses `pointerenter`/`pointerleave` gated to `pointerType === "mouse"`
+    — a tap's synthetic `mouseenter` never gets a matching `mouseleave` on
+    touch screens and would freeze rotation forever.
+  - `.csh--stopped` (persistent): the pause/play toggle button before the tab
+    strip — the WCAG 2.2.2 / APG-required rotation control, first in the
+    carousel's tab order, `aria-pressed` + swapped `aria-label`.
+  - `prefers-reduced-motion: reduce` disables the animation outright → no
+    `animationend` → no autoplay (manual navigation still works).
+- **Specificity gotcha:** the `animation:` shorthand resets
+  `animation-play-state` to `running`, so the paused/stopped rules must MATCH
+  the run rule's 5-class specificity and come after it. A shorter
+  `.csh.csh--paused .csh-nav__progress` rule silently loses — hover-pause
+  then never works.
+- **Single-slide degradation:** with one highlighted study the tab strip,
+  toggle, and autoplay are omitted and the slide renders WITHOUT
+  `role="tabpanel"`/`aria-labelledby` (they'd reference a tab that doesn't
+  exist — dangling ARIA idrefs fail axe).
+- **Tab strip centering:** `justify-content: center` lives on the OUTER
+  `.csh-nav` row; the inner `.csh-nav__tabs` group is the `overflow-x: auto`
+  scroller. Centering the scroll container itself would clip its left end once
+  tabs overflow.
+- The section heading/intro and the "See All Case Studies" button live in the
+  section content file, not the shortcode.
+
+---
+
 ## Modern layout — front matter schema
 
 ```yaml

--- a/layouts/shortcodes/case-study-slider.html
+++ b/layouts/shortcodes/case-study-slider.html
@@ -1,0 +1,262 @@
+{{- /*
+  Homepage case-study highlights slider (see docs/case-studies.md → Homepage slider).
+  One featured card per case study (logo pill, eyebrow, title, blurb, two stats,
+  CTA, photo) sliding in a track, with a client-logo tab strip as the navigation.
+  Card content comes from each case study's optional `highlight:` front matter,
+  falling back to title / description / preview_image / stat_bar / client_logo.
+  Set `highlight: false` on a case study to keep it out of the slider; any other
+  non-map value (e.g. `highlight: true`) includes it with pure fallbacks.
+*/ -}}
+{{- $pages := slice -}}
+{{- range (where site.RegularPages "Section" "case-studies").ByWeight -}}
+  {{- if ne .Params.highlight false -}}{{- $pages = $pages | append . -}}{{- end -}}
+{{- end -}}
+{{- $multi := gt (len $pages) 1 -}}
+<div class="csh" id="csHighlights">
+  <div class="csh__viewport">
+    <div class="csh__track">
+      {{- range $i, $p := $pages -}}
+      {{- $h := dict -}}
+      {{- if reflect.IsMap $p.Params.highlight -}}{{- $h = $p.Params.highlight -}}{{- end -}}
+      {{- $client := $p.Params.client | default $p.Title -}}
+      {{- $stats := $h.stats | default (first 2 ($p.Params.stat_bar | default slice)) -}}
+      <article
+        class="csh-slide{{ if eq $i 0 }} is-active{{ end }}"
+        id="csh-panel-{{ $i }}"
+        {{- if $multi }}
+        role="tabpanel"
+        aria-labelledby="csh-tab-{{ $i }}"
+        aria-hidden="{{ if eq $i 0 }}false{{ else }}true{{ end }}"
+        {{- end }}
+      >
+        <div class="csh-card">
+          <span class="csh-card__topline" aria-hidden="true"></span>
+          <div class="csh-card__body">
+            {{- with $h.logo | default $p.Params.client_logo }}
+            <div class="csh-card__logo">
+              <img src="{{ . }}" alt="{{ $client }} logo" loading="lazy" />
+            </div>
+            {{- end }}
+            <div class="csh-card__eyebrow">
+              {{ $h.eyebrow | default (printf "Case Study · %s" $client) | safeHTML }}
+            </div>
+            <h4 class="csh-card__title">
+              {{ $h.title | default $p.Title | safeHTML }}
+            </h4>
+            <p class="csh-card__blurb">
+              {{ $h.blurb | default $p.Description | safeHTML }}
+            </p>
+            {{- with $stats }}
+            <div class="csh-card__stats">
+              {{- range . }}
+              <div class="csh-stat">
+                <div class="csh-stat__value">{{ .value | safeHTML }}</div>
+                <div class="csh-stat__label">{{ .label | safeHTML }}</div>
+              </div>
+              {{- end }}
+            </div>
+            {{- end }}
+            <a class="button btn-gradient csh-card__cta" href="{{ $p.RelPermalink }}">
+              Read the Case Study &rarr;
+            </a>
+          </div>
+          {{- with $h.image | default $p.Params.preview_image }}
+          <div class="csh-card__media">
+            <img
+              src="{{ . }}"
+              alt="{{ $h.image_alt | default (printf `%s case study` $client) }}"
+              loading="lazy"
+            />
+          </div>
+          {{- end }}
+        </div>
+      </article>
+      {{- end }}
+    </div>
+  </div>
+  {{- if $multi }}
+  <div class="csh-nav">
+    {{- /* Rotation control first in the carousel's tab order (WCAG 2.2.2 / APG) */}}
+    <button
+      type="button"
+      class="csh-nav__toggle"
+      aria-label="Pause automatic slide rotation"
+      aria-pressed="false"
+    >
+      <svg class="csh-nav__icon-pause" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+        <path d="M4 2h3v12H4zM9 2h3v12H9z" />
+      </svg>
+      <svg class="csh-nav__icon-play" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+        <path d="M5 2l9 6-9 6z" />
+      </svg>
+    </button>
+    <div class="csh-nav__tabs" role="tablist" aria-label="Case studies">
+      {{- range $i, $p := $pages -}}
+      {{- $h := dict -}}
+      {{- if reflect.IsMap $p.Params.highlight -}}{{- $h = $p.Params.highlight -}}{{- end -}}
+      {{- $client := $p.Params.client | default $p.Title -}}
+      {{- $logo := $h.logo | default $p.Params.client_logo -}}
+      <button
+        type="button"
+        class="csh-nav__tab{{ if eq $i 0 }} is-active{{ end }}"
+        id="csh-tab-{{ $i }}"
+        role="tab"
+        aria-controls="csh-panel-{{ $i }}"
+        aria-selected="{{ if eq $i 0 }}true{{ else }}false{{ end }}"
+        aria-label="Show the {{ $client }} case study"
+      >
+        {{- if $logo }}
+        <img src="{{ $logo }}" alt="" loading="lazy" />
+        {{- else }}
+        <span class="csh-nav__name">{{ $client }}</span>
+        {{- end }}
+        <span class="csh-nav__bar" aria-hidden="true"><span class="csh-nav__progress"></span></span>
+      </button>
+      {{- end }}
+    </div>
+  </div>
+  {{- end }}
+</div>
+<script>
+  (function () {
+    document.querySelectorAll(".csh").forEach(function (root) {
+      var track = root.querySelector(".csh__track");
+      var slides = Array.prototype.slice.call(root.querySelectorAll(".csh-slide"));
+      var tabs = Array.prototype.slice.call(root.querySelectorAll(".csh-nav__tab"));
+      if (slides.length < 2) return;
+      var current = 0;
+
+      function setFocusable(slide, on) {
+        slide.querySelectorAll("a, button").forEach(function (el) {
+          el.tabIndex = on ? 0 : -1;
+        });
+      }
+
+      function go(i) {
+        current = (i + slides.length) % slides.length;
+        track.style.transform = "translateX(" + -100 * current + "%)";
+        slides.forEach(function (s, n) {
+          var on = n === current;
+          s.classList.toggle("is-active", on);
+          s.setAttribute("aria-hidden", on ? "false" : "true");
+          setFocusable(s, on);
+        });
+        tabs.forEach(function (t, n) {
+          var on = n === current;
+          t.classList.toggle("is-active", on);
+          t.setAttribute("aria-selected", on ? "true" : "false");
+          t.tabIndex = on ? 0 : -1;
+        });
+      }
+
+      tabs.forEach(function (t, n) {
+        t.addEventListener("click", function () {
+          go(n);
+        });
+        t.addEventListener("keydown", function (e) {
+          if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+          e.preventDefault();
+          go(current + (e.key === "ArrowRight" ? 1 : -1));
+          tabs[current].focus();
+        });
+      });
+
+      // Autoplay is driven by the active tab's progress-bar animation: when the
+      // bar finishes filling, advance. Pausing the animation pauses the slider.
+      root.querySelectorAll(".csh-nav__progress").forEach(function (p) {
+        p.addEventListener("animationend", function () {
+          go(current + 1);
+        });
+      });
+
+      // Hover and focus each hold the pause independently, so leaving with the
+      // mouse can't resume rotation while keyboard focus is still inside (an
+      // auto-advance would hide the focused element and drop focus to <body>).
+      // pointerType-gated so a tap's synthetic mouseenter (which never gets a
+      // matching mouseleave on touch screens) can't freeze the rotation.
+      var hovered = false;
+      var focused = false;
+      function updatePaused() {
+        root.classList.toggle("csh--paused", hovered || focused);
+      }
+      root.addEventListener("pointerenter", function (e) {
+        if (e.pointerType !== "mouse") return;
+        hovered = true;
+        updatePaused();
+      });
+      root.addEventListener("pointerleave", function (e) {
+        if (e.pointerType !== "mouse") return;
+        hovered = false;
+        updatePaused();
+      });
+      root.addEventListener("focusin", function () {
+        focused = true;
+        updatePaused();
+      });
+      root.addEventListener("focusout", function (e) {
+        focused = root.contains(e.relatedTarget);
+        updatePaused();
+      });
+
+      // Persistent rotation control (WCAG 2.2.2): stops autoplay until toggled
+      // back on, independent of the transient hover/focus pause.
+      var toggle = root.querySelector(".csh-nav__toggle");
+      if (toggle) {
+        toggle.addEventListener("click", function () {
+          var stopped = root.classList.toggle("csh--stopped");
+          toggle.setAttribute("aria-pressed", stopped ? "true" : "false");
+          toggle.setAttribute(
+            "aria-label",
+            stopped ? "Resume automatic slide rotation" : "Pause automatic slide rotation"
+          );
+        });
+      }
+
+      // Only run the autoplay while a meaningful part of the slider is on
+      // screen. isIntersecting alone flips true at the first visible pixel, so
+      // gate on the ratio: on once ≥25% visible, off only when fully off-screen.
+      if ("IntersectionObserver" in window) {
+        new IntersectionObserver(
+          function (entries) {
+            entries.forEach(function (entry) {
+              root.classList.toggle(
+                "csh--inview",
+                entry.isIntersecting && entry.intersectionRatio >= 0.2
+              );
+            });
+          },
+          { threshold: [0, 0.25] }
+        ).observe(root);
+      } else {
+        root.classList.add("csh--inview");
+      }
+
+      var x0 = null;
+      var y0 = null;
+      var viewport = root.querySelector(".csh__viewport");
+      viewport.addEventListener(
+        "touchstart",
+        function (e) {
+          x0 = e.touches[0].clientX;
+          y0 = e.touches[0].clientY;
+        },
+        { passive: true }
+      );
+      viewport.addEventListener(
+        "touchend",
+        function (e) {
+          if (x0 === null) return;
+          var dx = e.changedTouches[0].clientX - x0;
+          var dy = e.changedTouches[0].clientY - y0;
+          if (Math.abs(dx) > 48 && Math.abs(dx) > Math.abs(dy)) {
+            go(current + (dx < 0 ? 1 : -1));
+          }
+          x0 = y0 = null;
+        },
+        { passive: true }
+      );
+
+      go(0);
+    });
+  })();
+</script>


### PR DESCRIPTION
New homepage section between Efficient Platforms and the testimonials: one dark pine card per case study (client logo pill, category eyebrow, short title, blurb, two headline metrics, CTA, photo) on a sliding track, navigated by a client-logo tab strip with an autoplay progress bar — the Microsoft-customer-stories pattern in Masterpoint's theme.

- layouts/shortcodes/case-study-slider.html: markup + self-contained vanilla JS (the global flexslider init would fight logo-tab nav). Autoplay advances on the progress bar's animationend, pauses on hover/focus (tracked independently so mouse-leave can't resume while keyboard focus is inside), has a persistent pause/play rotation control (WCAG 2.2.2), only runs while ≥25% on screen, and is fully disabled under prefers-reduced-motion. Touch swipe + arrow keys.
- Card content comes from a new optional `highlight:` front-matter map on each case study (eyebrow/title/blurb/image/logo/2 stats), with fallbacks to title/description/preview_image/stat_bar/client_logo; `highlight: false` opts out, non-map values can't crash the build (reflect.IsMap guard). Single-slide mode drops tab ARIA + autoplay.
- Styles in custom.scss (.csh-*), echoing the case-study hero (pine gradient, dot grid, mint/pink glows, brand-gradient stat values).
- Docs: new "Homepage highlights slider" section in docs/case-studies.md.


Claude-Session: https://claude.ai/code/session_01UrsnEwWx53uzzFEyD5coNs

## what

- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.

## why

- Provide the justifications for the changes (e.g. business case).
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.

## references

- Link to any supporting GitHub issues or helpful documentation to add some context (e.g. Stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
