### PR TITLE
feat: adds purpose + values section to Who We Are page

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -2772,23 +2772,6 @@ footer {
   @media (max-width: 767px) {
     padding: 3.5rem 0 3rem;
   }
-
-  .bg-image {
-    width: 100%;
-    position: absolute;
-    &:before {
-      background:
-        linear-gradient(
-          180deg,
-          rgba(0, 0, 0, 0.8) -18.07%,
-          rgba(0, 0, 0, 0) 91.05%
-        ),
-        linear-gradient(360deg, $pine 3.27%, rgba(14, 56, 58, 0) 56.1%);
-    }
-    img {
-      opacity: 0.24;
-    }
-  }
 }
 
 .valuesPurpose {
@@ -2817,8 +2800,7 @@ footer {
   }
 }
 
-#values-who-row,
-#values-how-row {
+#values-who-row {
   justify-content: center;
   .col {
     margin-top: 1.22rem;
@@ -2855,17 +2837,6 @@ footer {
         line-height: 1.42em;
         margin-bottom: 0;
       }
-    }
-  }
-}
-
-#values-how-row {
-  .card .card-body {
-    padding: 1.8rem 3.5rem;
-    max-width: 900px;
-    margin: 0 auto;
-    @media (max-width: 767px) {
-      padding: 1.5rem;
     }
   }
 }

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -2763,6 +2763,113 @@ footer {
   color: $pine;
 }
 
+#who-our-values {
+  padding: 5.3rem 0 4.5rem;
+  position: relative;
+  color: #fff;
+  background: $pine;
+
+  @media (max-width: 767px) {
+    padding: 3.5rem 0 3rem;
+  }
+
+  .bg-image {
+    width: 100%;
+    position: absolute;
+    &:before {
+      background:
+        linear-gradient(
+          180deg,
+          rgba(0, 0, 0, 0.8) -18.07%,
+          rgba(0, 0, 0, 0) 91.05%
+        ),
+        linear-gradient(360deg, $pine 3.27%, rgba(14, 56, 58, 0) 56.1%);
+    }
+    img {
+      opacity: 0.24;
+    }
+  }
+}
+
+.valuesPurpose {
+  font-weight: 700;
+  font-size: 1.75rem;
+  line-height: 1.36em;
+  letter-spacing: -0.03em;
+  max-width: 750px;
+  margin: 0 auto;
+  padding-bottom: 0.5em;
+
+  @media (max-width: 991px) {
+    font-size: 1.5rem;
+  }
+  @media (max-width: 575px) {
+    font-size: 1.3rem;
+  }
+}
+
+.valuesGroupTitle {
+  margin-top: 2.4rem;
+  margin-bottom: 0.2rem;
+
+  @media (max-width: 767px) {
+    margin-top: 1.6rem;
+  }
+}
+
+#values-who-row,
+#values-how-row {
+  justify-content: center;
+  .col {
+    margin-top: 1.22rem;
+    margin-bottom: 1.1rem;
+  }
+  .card {
+    border-radius: 3.33rem;
+    background: linear-gradient(
+      54deg,
+      rgba(95, 220, 182, 0.16) 22.51%,
+      rgba(42, 217, 194, 0.16) 45.75%,
+      rgba(138, 177, 201, 0.16) 63.83%
+    );
+    @media (max-width: 767px) {
+      border-radius: 1.5rem;
+    }
+    .card-body {
+      padding: 1.9rem 2.1rem 2rem;
+      text-align: center;
+      @media (max-width: 767px) {
+        padding: 1.5rem;
+      }
+      h4 {
+        font-size: 1.44rem;
+        line-height: 1.15em;
+        padding-bottom: 0.5em;
+        @media (max-width: 767px) {
+          font-size: 1.3rem;
+        }
+      }
+      p {
+        font-size: 1.05rem;
+        font-weight: 400;
+        line-height: 1.42em;
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+
+#values-how-row {
+  .card .card-body {
+    padding: 1.8rem 3.5rem;
+    max-width: 900px;
+    margin: 0 auto;
+    @media (max-width: 767px) {
+      padding: 1.5rem;
+    }
+  }
+}
+
 #page-services {
   #banner {
     padding: 10.45rem 0 8.1rem;

--- a/content/sections/who-our-values.md
+++ b/content/sections/who-our-values.md
@@ -1,0 +1,37 @@
+---
+title: Our Values
+weight: 4
+position: justify-content-center text-center
+size: col-12
+image: /img/bg_our_team.jpg
+section_categories:
+  - who-we-are
+id: who-our-values
+
+values_who:
+  - title: "We communicate with excellence."
+    intro: "We are deliberate, explicit, and empathetic communicators. We listen to understand — not just to respond — and we hear the deeper concern behind what's being said. We believe being a good communicator starts with being a good listener."
+  - title: "We are experts with a point of view."
+    intro: "We stay well-read and current in our craft. We bring patterns, methodology, and opinions backed by experience. We are always improving, always curious, always bringing better thinking to the work."
+  - title: "We work with autonomy and high agency."
+    intro: "We take ownership and make sound decisions independently. We take things from start to finish with confidence. When we hear a critical issue from a client, we take it on — we don't wait to be asked."
+
+values_how:
+  - title: "We believe in balance."
+    intro: "We make honest commitments and exceed them sustainably. We create value beyond what the conversation started with. We're building a company where great work and a good life go together."
+---
+
+<!-- Section partials start at h3: the page banner owns the higher heading levels. -->
+<!-- markdownlint-disable MD001 -->
+
+### Our Purpose {.sectionTitle .big .text-gradient .text-center .d-inline-block .mb-0}
+
+<p class="valuesPurpose">We untangle infrastructure and upskill the teams who own it.</p>
+
+#### Who We Are {.groupTitle .text-gradient .text-center .d-inline-block .valuesGroupTitle}
+
+{{< cards key="values_who" col="col-sm-6 col-md-4" id="values-who-row" >}}
+
+#### How We Work {.groupTitle .text-gradient .text-center .d-inline-block .valuesGroupTitle}
+
+{{< cards key="values_how" col="col-12" id="values-how-row" >}}

--- a/content/sections/who-our-values.md
+++ b/content/sections/who-our-values.md
@@ -1,24 +1,19 @@
 ---
 title: Our Values
-weight: 4
+weight: 3
 position: justify-content-center text-center
 size: col-12
-image: /img/bg_our_team.jpg
 section_categories:
   - who-we-are
 id: who-our-values
 
-values_who:
+cards:
   - title: "We communicate with excellence."
     intro: "We are deliberate, explicit, and empathetic communicators. We listen to understand — not just to respond — and we hear the deeper concern behind what's being said. We believe being a good communicator starts with being a good listener."
   - title: "We are experts with a point of view."
     intro: "We stay well-read and current in our craft. We bring patterns, methodology, and opinions backed by experience. We are always improving, always curious, always bringing better thinking to the work."
   - title: "We work with autonomy and high agency."
     intro: "We take ownership and make sound decisions independently. We take things from start to finish with confidence. When we hear a critical issue from a client, we take it on — we don't wait to be asked."
-
-values_how:
-  - title: "We believe in balance."
-    intro: "We make honest commitments and exceed them sustainably. We create value beyond what the conversation started with. We're building a company where great work and a good life go together."
 ---
 
 <!-- Section partials start at h3: the page banner owns the higher heading levels. -->
@@ -28,10 +23,6 @@ values_how:
 
 <p class="valuesPurpose">We untangle infrastructure and upskill the teams who own it.</p>
 
-#### Who We Are {.groupTitle .text-gradient .text-center .d-inline-block .valuesGroupTitle}
+#### Our Values {.groupTitle .text-gradient .text-center .d-inline-block .valuesGroupTitle}
 
-{{< cards key="values_who" col="col-sm-6 col-md-4" id="values-who-row" >}}
-
-#### How We Work {.groupTitle .text-gradient .text-center .d-inline-block .valuesGroupTitle}
-
-{{< cards key="values_how" col="col-12" id="values-how-row" >}}
+{{< cards col="col-sm-6 col-md-4" id="values-who-row" >}}

--- a/content/sections/who-we-support.md
+++ b/content/sections/who-we-support.md
@@ -1,12 +1,12 @@
 ---
 title: Who We Support
-weight: 3
+weight: 4
 position: justify-content-center text-center
 size: col-12 col-md-12 col-lg-8
 #section_image: /img/img_matt_gowie.png
 #image: /img/bg_our_team.jpg
 section_categories:
-    - who-we-are
+  - who-we-are
 id: section-who-we-support
 ---
 

--- a/layouts/shortcodes/cards.html
+++ b/layouts/shortcodes/cards.html
@@ -1,8 +1,7 @@
 {{ $col := .Get "col" | default "col-md-6" }}
 {{ $id := .Get "id" }}
-{{ $key := .Get "key" | default "cards" }}
 
-{{ with index .Page.Params $key }}
+{{ with .Page.Params.cards }}
 <div class="row row-cards" id="{{ $id }}">
     {{ range . }}
     <div class="col col-12 {{ $col }}">

--- a/layouts/shortcodes/cards.html
+++ b/layouts/shortcodes/cards.html
@@ -1,7 +1,8 @@
 {{ $col := .Get "col" | default "col-md-6" }}
 {{ $id := .Get "id" }}
+{{ $key := .Get "key" | default "cards" }}
 
-{{ with .Page.Params.cards }}
+{{ with index .Page.Params $key }}
 <div class="row row-cards" id="{{ $id }}">
     {{ range . }}
     <div class="col col-12 {{ $col }}">


### PR DESCRIPTION
## what

- Adds a **Purpose + Values** section to the [Who We Are](https://masterpoint.io/who-we-are/) page, built from Robin's Notion draft.
  - **Our Purpose** — "We untangle infrastructure and upskill the teams who own it."
  - **Our Values** — the three values, as a 3-up card row.
- Slots in between **Our Team** and **Who We Support** (`weight: 3`; Who We Support bumps to `4`).
- Reuses the existing `cards` shortcode as-is and the `#what-get-row` card treatment, so this adds no new components.

## why

- We've never had our values on the site. This puts our purpose and how we operate in front of prospective clients and candidates, on the page where people already go to understand who we are.
- Sitting after the team bubbles means a visitor meets the people first, then what those people stand for, before moving on to who we support.
- The section renders on solid pine rather than a background image: it now sits directly below Our Team, which is also dark, and a busy image at that boundary washed out the translucent cards. Solid pine matches `#iac-what-you-get`, where this card treatment already lives.

## notes for review

- Copy is Robin's, verbatim. The only editorial change is the group heading, renamed from "Who We Are" to **"Our Values"** — the original duplicated the page's own title.
- The draft's **"How We Work"** group (and its single value, "We believe in balance") is intentionally **not** included.
- Verified at desktop (1280) and mobile (375) against Netlify's own build: cards stack cleanly, no horizontal overflow, equal heights via the shortcode's `h-100`.
- `trunk fmt` + `trunk check` clean. The one `MD001` hit is the same heading-level pattern every other `content/sections/*.md` file has (they're baselined); disabled inline with a comment explaining why section partials start at `h3`.

## references

- Source: [Masterpoint Values (Draft for web site)](https://app.notion.com/p/masterpoint/Masterpoint-Values-Draft-for-web-site-39c859758a56807682fdd24b8637e234) — Notion, by Robin
- Deploy preview renders the section at `/who-we-are/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
