### PR TITLE
chore: strengthen blog and case study internal links

### DIFF
--- a/content/blog/2024-08-22-terralith-monolithic-terraform-architecture.md
+++ b/content/blog/2024-08-22-terralith-monolithic-terraform-architecture.md
@@ -5,7 +5,7 @@ title: "The Terralith: Monolithic Architecture of Terraform & Infrastructure as 
 author: Yangci Ou
 slug: terralith-monolithic-terraform-architecture
 date: 2024-08-22
-# date_modified: 2025-xx-xx Be sure to use this if you've updated the post as this helps with SEO and index freshness
+date_modified: 2026-08-18
 description: This article explores the challenges and pitfalls of Terralith, a monolithic Terraform architecture in Infrastructure as Code, and uncovers why a Terralith is not a good practice.
 image: /img/updates/terralith/terralith-article.png
 preview_image: /img/updates/terralith/terralith-preview-image.png # Use preview_image to prevent image overflow, best aspect ratios 270x355 or 600x700
@@ -71,7 +71,7 @@ Imagine a Terralith’s state file like a single, massive spreadsheet tracking e
 
 In IaC, the workflow first checks all resources against the real infrastructure, then plans the changes from your infrastructure code, and finally executes the plan by applying it. Even if we are trying to modify something as minor as renaming one resource, **the system must verify against every single resource in the state file**.
 
-It’s a domino effect because this not only slows down the development and deployment process, but also increases the vulnerability to transient errors such as credential expirations and API rate limits. At Masterpoint, we've had clients with Terralith codebases which took over 30+ minutes for simple plans and applies. As you can imagine, they often timed out or reached the API limits.
+It’s a domino effect because this not only slows down the development and deployment process, but also increases the vulnerability to transient errors such as credential expirations and API rate limits. At Masterpoint, we've had clients with Terralith codebases which took over 30+ minutes for simple plans and applies. As you can imagine, they often timed out or reached the API limits. If you need to prove which resources are causing the slowdown before committing to a refactor, use [OpenTofu's `-exclude` flag to isolate the performance bottleneck](https://masterpoint.io/blog/using-opentofu-exclude-flag-isolate-performance-bottlenecks/).
 
 ![Terralith API Limit Example](/img/updates/terralith/terralith-api-limit-example.png) <!-- API Limit Screenshot -->
 
@@ -95,7 +95,7 @@ Breaking up a monolithic TF architecture is like splitting each floor of the sky
 
 Of course, there are scenarios where a Terralith might make sense, such as smaller projects, prototyping, and proof of concepts. “But as you evolve, as you have more teams and more complicated setups, you need to think about [blast radius, state management, and architecture],” as said by [Nicki Watt](https://www.hashicorp.com/resources/evolving-infrastructure-terraform-opencredo).
 
-While the specific end structure will vary based on organizational needs, a general approach to breaking up a Terralith involves splitting infrastructure into different services and drawing clear boundaries around them. You have a few options to do this. At Masterpoint, we typically create root modules at the service boundary: AWS RDS clusters, AWS SQS Queues, Lambda Functions, and ECS Services all get their own root module. Then we instantiate instances of these root modules with specific configuration for each time the service is used within our client’s infrastructure. For example, if you have a prod and a staging database, the same AWS RDS root module would be configured differently and used two times.
+While the specific end structure will vary based on organizational needs, a general approach to breaking up a Terralith involves splitting infrastructure into different services and drawing clear boundaries around them. You have a few options to do this. At Masterpoint, we typically create root modules at the service boundary: AWS RDS clusters, AWS SQS Queues, Lambda Functions, and ECS Services all get their own root module. Then we instantiate instances of these root modules with specific configuration for each time the service is used within our client’s infrastructure. For example, if you have a prod and a staging database, the same AWS RDS root module would be configured differently and used two times. For the migration sequence, backups, and state moves, see our guide on [breaking up a Terralith](https://masterpoint.io/blog/steps-to-break-up-a-terralith/).
 
 [TF Workspaces](https://opentofu.org/docs/language/state/workspaces/) is another method to manage this complexity. By leveraging workspaces, teams can maintain separation between environments while reusing the same TF codebase. This approach adheres to the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle, reducing duplication and helping some of the pitfalls mentioned above.
 

--- a/content/blog/2024-10-10-migrate-off-tfc.md
+++ b/content/blog/2024-10-10-migrate-off-tfc.md
@@ -5,7 +5,7 @@ title: "How to Migrate off Terraform Cloud"
 author: Veronika Gnilitska
 slug: how-to-migrate-off-tfc
 date: 2024-10-10
-# date_modified: 2025-xx-xx Be sure to use this if you've updated the post as this helps with SEO and index freshness
+date_modified: 2026-08-18
 description: "Need to to migrate off Terraform Cloud? We're happy to share some tips about preparation, pitfalls, and the process itself based on Masterpoint's experience."
 image: /img/updates/migrate-off-tfc/main.webp
 preview_image: /img/updates/migrate-off-tfc/preview.webp
@@ -68,7 +68,7 @@ To migrate the state, you must use the Terraform [API](https://www.terraform.io/
 
 This extra step makes the migration process more labor-intensive compared to other backends. We’ve found [this detailed guide on downloading your Terraform state files to be helpful](https://github.com/hashicorp/terraform/issues/33214#issuecomment-1553223031). It is a GitHub comment by a HashiCorp team member.
 
-Ensure your new storage solution is configured correctly to handle Terraform state files, including appropriate redundancy, access permissions, and encryption settings. While there are other options, we encourage our clients to utilize their primary cloud’s object storage solution, like AWS S3, Google Cloud Storage, or Azure’s Blob Storage, to ensure that the infrastructure management process is secure, reliable, and integrated within the broader cloud environment. If you want a jumpstart on using S3 as your state storage, [check out Cloud Posse’s tfstate-backend module](https://github.com/cloudposse/terraform-aws-tfstate-backend).
+Ensure your new storage solution is configured correctly to handle Terraform state files, including appropriate redundancy, access permissions, and encryption settings. While there are other options, we encourage our clients to utilize their primary cloud’s object storage solution, like AWS S3, Google Cloud Storage, or Azure’s Blob Storage, to ensure that the infrastructure management process is secure, reliable, and integrated within the broader cloud environment. For the rationale and a complete S3 example, see [why cloud object storage is the best Terraform remote backend](https://masterpoint.io/blog/why-use-cloud-object-storage-terraform-remote-backend/). If you want a jumpstart on using S3 as your state storage, [check out Cloud Posse’s tfstate-backend module](https://github.com/cloudposse/terraform-aws-tfstate-backend).
 
 ## Variables and Secrets Management
 
@@ -97,7 +97,7 @@ Consider these questions for your migration plan:
 1. Do you have a cost analysis tool that needs to be implemented in your new solution?
 1. Do you have infrastructure management access policies that need to be implemented in your new solution? Think of Sentinel or OPA.
 1. Do you have any security scanning that needs to be implemented in your new solution? Consider integrating with Snyk or other similar tools.
-1. Do you have any webhooks or notifications executed from Terraform Cloud? You’ll need to migrate the configuration, including tokens, recipients, and anything else.
+1. Do you have any webhooks or notifications executed from Terraform Cloud? You’ll need to migrate the configuration, including tokens, recipients, and anything else. Our guide to [efficient Terraform automation notifications](https://masterpoint.io/blog/importance-of-efficient-notifications-terraform-automation/) covers how to keep failure alerts useful after the move.
 1. Do you run Drift Detection for any of your Terraform Cloud Workspaces? Do you need your new solution to have analogous functionality?
 
 Finding the answers to these questions for your organization and coming up with a plan to deal with each use case in the planning phase will help ensure a smooth migration.
@@ -191,7 +191,7 @@ Here’s the promised [checklist](https://docs.google.com/document/d/1ibwIi3gKIx
 
 Migrating off Terraform Cloud requires careful planning and execution, but by following these tips, you can achieve a smooth transition. Remember to document your migration process, communicate with your team, and continuously test and refine your approach.
 
-With the right preparation, you'll be well on your way to managing your infrastructure with greater control and flexibility.
+With the right preparation, you'll be well on your way to managing your infrastructure with greater control and flexibility. For a 43,000-resource migration from Terraform Cloud to Spacelift and OpenTofu, see the [Power Digital case study](https://masterpoint.io/case-studies/power-digital/).
 
 Finally, feel free to [reach out to us](https://masterpoint.io/contact/) if you need help or a second set of eyes.
 

--- a/content/blog/2025-03-06-steps-to-break-up-a-terralith.md
+++ b/content/blog/2025-03-06-steps-to-break-up-a-terralith.md
@@ -5,7 +5,7 @@ title: "Steps to Break Up a Terralith"
 author: Veronika Gnilitska
 slug: steps-to-break-up-a-terralith
 date: 2025-03-06
-# date_modified: 2025-xx-xx Be sure to use this if you've updated the post as this helps with SEO and index freshness
+date_modified: 2026-08-18
 description: In this follow-up to our "What Is a Terralith?" article, we shift the focus from describing the problem to providing a detailed migration plan, practical guidance, and a handy checklist for breaking up a Terralith into smaller, more manageable root modules.
 image: /img/updates/steps-to-break-up-a-terralith/main.png
 preview_image: /img/updates/steps-to-break-up-a-terralith/preview.png
@@ -49,7 +49,7 @@ Let’s take a look at the typical symptoms of a Terralith:
 
 - **Large state file(s)**: A large number of resources are stuffed into a single `.tfstate` state file. There’s no universally correct file size or resource count for TF. However, our experience suggests that **if your state files have between a few hundred and 1000+ resources** then you're likely dealing with performance and manageability issues. Not all APIs are the same, so that might not be the case for you, but we're painting with a broad brush here to give you an idea. Ideally, your TF root modules are built around service boundaries that share the same lifecycle, allowing for easy division.
 - **One big root module**: There is no clear separation of concern or logical grouping of services, such as databases, networking, and DNS. While deciding how to segment resources can be complex, a foundational best practice is to place unrelated resources in separate root modules. For example, if a Route 53 alias is only used by Service A — and never by Service B — avoid defining it in the same module as Service B.
-- **Slow plan/apply operations**: Having many resources in a single state file can cause TF `plan` and `apply` operations to slow down considerably. Even if you don’t know the exact file size or resource count, experiencing sluggish performance is a sign. If your plan regularly takes 10 minutes or more, congrats, you have a Terralith! This issue can also arise when a root module manages many of the same resource types, such as DataDog monitors. In these cases, consider restructuring your configuration (e.g., grouping monitors into logical modules based on who owns them in the organization or their business impact).
+- **Slow plan/apply operations**: Having many resources in a single state file can cause TF `plan` and `apply` operations to slow down considerably. Even if you don’t know the exact file size or resource count, experiencing sluggish performance is a sign. If your plan regularly takes 10 minutes or more, congrats, you have a Terralith! This issue can also arise when a root module manages many of the same resource types, such as DataDog monitors. In these cases, consider restructuring your configuration (e.g., grouping monitors into logical modules based on who owns them in the organization or their business impact). Before beginning a breakup, you can [use OpenTofu's `-exclude` flag to isolate the performance bottleneck](https://masterpoint.io/blog/using-opentofu-exclude-flag-isolate-performance-bottlenecks/) and confirm where the time is actually going.
 - **Complex deployments**: If your deployment process frequently relies on partial or “targeted” applies — for example, using `terraform apply -target=<resource>` — or other manual interventions, your root module resources are too entangled.
 - **High blast radius**: If even a small change or upgrade in one part of the infrastructure can affect unrelated components, you probably have a Terralith. This situation increases operational risk.
 
@@ -360,7 +360,7 @@ Ready to move from theory to action? We’ve consolidated everything into a sing
 
 Breaking up a Terralith into smaller, more manageable modules is **crucial** for organizations seeking to improve speed, reduce risk, and follow modular best practices in Infrastructure as Code. While newer Terraform/OpenTofu features like `import` and `remove` blocks have made migrations easier, there is still complexity and potential for error. Hence, our emphasis on scripts, backups, careful planning, and validation.
 
-While the process requires care during planning and execution, the benefits of a modular and maintainable infrastructure are well worth the effort.
+While the process requires care during planning and execution, the benefits of a modular and maintainable infrastructure are well worth the effort. See how we decomposed a 43,000+ resource Terralith for [Power Digital](https://masterpoint.io/case-studies/power-digital/).
 
 If you need assistance or have questions about the process, our team at Masterpoint are the go-to experts in IaC. We’ve done this dozens of times and can help guide you through breaking up your Terralith and setting up future-proof IaC.
 

--- a/content/blog/2025-04-01-importance-of-efficient-notifications-terraform-automation.md
+++ b/content/blog/2025-04-01-importance-of-efficient-notifications-terraform-automation.md
@@ -5,7 +5,7 @@ title: "Importance of Efficient Notifications in Terraform & IaC Automation"
 author: Yangci Ou
 slug: importance-of-efficient-notifications-terraform-automation
 date: 2025-04-01
-# date_modified: 2025-xx-xx Be sure to use this if you've updated the post as this helps with SEO and index freshness
+date_modified: 2026-08-18
 description: Explore how unnoticed Terraform & Infrastructure as Code (IaC) failures can lead to significant problems, and how efficient notification alerts can prevent issues from cascading into major operational disruptions.
 image: /img/updates/efficient-notifications-terraform-automation/terraform-automation-notifications.png
 callout: <p>👋 <b>If you're ready to take your infrastructure to the next level, we're here to help. We love to work together with engineering teams to help them build well-documented, scalable, automated IaC that make their jobs easier. <a href='/contact'>Get in touch!</a></p>
@@ -30,7 +30,7 @@ Because there are so many factors involved in cloud infrastructure, there’s mo
 
 But do you know what’s way worse than a failed TF deployment? A deployment failure that doesn’t get noticed **for days**.
 
-In this article, we'll talk through this problem and share how we believe it should be handled. We'll include specifics on how we do this today with [Spacelift](https://spacelift.io/) for our clients.
+In this article, we'll talk through this problem and share how we believe it should be handled. We'll include specifics on how we do this today with [Spacelift](https://spacelift.io/) for our clients. If you are weighing that move, start with our guide on [migrating off Terraform Cloud](https://masterpoint.io/blog/how-to-migrate-off-tfc/).
 
 ## The Silent Failure Problem in IaC Deployments
 

--- a/content/blog/2025-04-17-using-mcps-to-run-terraform.md
+++ b/content/blog/2025-04-17-using-mcps-to-run-terraform.md
@@ -4,7 +4,7 @@ draft: false
 title: "Using MCPs to Run Terraform"
 author: Weston Platter
 date: 2025-04-17
-# date_modified: 2025-xx-xx Be sure to use this if you've updated the post as this helps with SEO and index freshness
+date_modified: 2026-08-18
 slug: using-mcps-to-run-terraform
 description: "We jump into a hands-on exploration of Model Context Protocol (MCP), sharing our experiment using a MCP client to run terraform init, plan, apply. We share our take on where agents add value and highlight security considerations when adding MCPs to your workflow."
 image: /img/updates/using-mcps-to-run-terraform/header5.png
@@ -99,7 +99,7 @@ Example Cursor `mcp.json` config file
 
 ### Terraform code
 
-From there, I added a `main.tf` file in the configured `TERRAFORM_DIR` and wrote some basic terraform code to provision the Postgres resources:
+From there, I added a [`main.tf` file](https://masterpoint.io/blog/standard-tf-files/#maintf-resource-definitions-and-primary-infrastructure) in the configured `TERRAFORM_DIR` and wrote some basic terraform code to provision the Postgres resources. The example pins its provider version; see our [Terraform versioning guide](https://masterpoint.io/blog/ultimate-terraform-versioning-guide/) for how to choose compatible constraints:
 
 - **Terraform block**: sets the required provider, `cyrilgdn/postgresql`
 - **Provider config**: connects to a local Postgres instance as `admin_user`
@@ -198,7 +198,7 @@ My takeaways from the experience:
 
 {{< lightboximg "/img/updates/using-mcps-to-run-terraform/mcp-collective.png" "Collection of MCPs" >}}
 
-- **Surfacing feedback loops is where agentic tools can shine.** Most of the pain in this experiment came from not seeing the error — not from the error itself. Agentic workflows that help you interpret state, errors, or diff outputs (and offer remediations) are more valuable than abstracting away the command execution. The real unlock isn’t just running `terraform apply` — it’s making sense of what went wrong and suggesting what to do next.
+- **Surfacing feedback loops is where agentic tools can shine.** Most of the pain in this experiment came from not seeing the error — not from the error itself. Agentic workflows that help you interpret state, errors, or diff outputs (and offer remediations) are more valuable than abstracting away the command execution. The real unlock isn’t just running `terraform apply` — it’s making sense of what went wrong and suggesting what to do next. For a testing-focused example of putting AI assistance to work in Terraform code, read [our prompt strategies for test generation](https://masterpoint.io/blog/ai-meets-tf-prompt-strategies-for-test-generation/).
 
 <br>
 

--- a/content/blog/2025-05-21-tf-terminology-breakdown.md
+++ b/content/blog/2025-05-21-tf-terminology-breakdown.md
@@ -5,7 +5,7 @@ title: Terraform + OpenTofu Terminology Breakdown
 slug: terraform-opentofu-terminology-breakdown
 author: Matt Gowie
 date: 2025-05-21
-date_modified: 2026-07-22 # Be sure to use this if you've updated the post as this helps with SEO and index freshness
+date_modified: 2026-08-18
 description: List of Terraform and OpenTofu terms with definitions and explanations.
 image: /img/updates/tf-terminology-breakdown.png
 callout: <p>👋 <b>Got a term that you're still confused on in the TF or IaC space that you want us to include here? <a href='/contact'>Get in touch and we'd be happy to add it!</a></b></p>
@@ -45,7 +45,7 @@ callout: <p>👋 <b>Got a term that you're still confused on in the TF or IaC sp
 
 # Intro
 
-The Terraform and OpenTofu (collectively referred to as "TF") ecosystem has evolved significantly since HashiCorp's initial release, and the growing sea of tooling and management platforms has led to some interesting (and occasionally frustrating) terminology fragmentation. We're going to break down some essential TF terminology that you'll encounter: workspaces, modules, state management, testing frameworks, and more.
+The Terraform and OpenTofu (collectively referred to as "TF") ecosystem has evolved significantly since HashiCorp's initial release, and the growing sea of tooling and management platforms has led to some interesting (and occasionally frustrating) terminology fragmentation. We're going to break down some essential TF terminology that you'll encounter: workspaces, modules, state management, testing frameworks, and more. For practical examples of what teams manage with TF beyond application infrastructure, see [three Terraform use cases to implement](https://masterpoint.io/blog/terraform-use-cases/).
 
 # Workspaces
 
@@ -73,7 +73,7 @@ Modules are one of the most important elements of TF for organizing your infrast
 
 ## Root Modules
 
-Root modules serve as the main working directory where Terraform or OpenTofu is executed (that is, planned and then applied to bring your infrastructure into line with your IaC config). These modules contain your primary configuration files (main.tf, variables.tf, providers.tf, versions.tf, etc.) and are typically responsible for consuming and composing child modules. Think of root modules as the orchestrators of your infrastructure. They map to one or many state files and they're where you bring together all the pieces of your configuration.
+Root modules serve as the main working directory where Terraform or OpenTofu is executed (that is, planned and then applied to bring your infrastructure into line with your IaC config). These modules contain your primary configuration files (main.tf, variables.tf, providers.tf, versions.tf, etc.) and are typically responsible for consuming and composing child modules. Think of root modules as the orchestrators of your infrastructure. They map to one or many state files and they're where you bring together all the pieces of your configuration. See [the standard Terraform and OpenTofu files](https://masterpoint.io/blog/standard-tf-files/) for what belongs in each one, and the [Terraform versioning guide](https://masterpoint.io/blog/ultimate-terraform-versioning-guide/) for choosing compatible CLI and provider constraints.
 
 ## Child Modules
 

--- a/content/blog/2025-07-17-platform-engineering-way-to-manage-google-workspace-users.md
+++ b/content/blog/2025-07-17-platform-engineering-way-to-manage-google-workspace-users.md
@@ -4,7 +4,7 @@ draft: false
 title: "The Platform Engineering Way to Manage Google Workspace Users"
 author: Weston Platter
 date: 2025-07-17
-# date_modified: 2025-xx-xx Be sure to use this if you've updated the post as this helps with SEO and index freshness
+date_modified: 2026-08-18
 slug: platform-engineering-way-to-manage-google-workspace-users
 description: "Migrate Google Workspace from ClickOps to Infrastructure as Code with our open source Terraform module. Includes design patterns and import examples."
 tags: ["terraform", "google-workspace", "infrastructure-as-code", "automation"]
@@ -71,7 +71,7 @@ To make the module easy to get up and running with your own Google Workspace, we
 1. **Import existing Google Workspace users and groups**
    We expect most people will use the module with an existing Google Workspace. To make this easy, we included the Terraform and YAML configuration files we used to import our own workspace users and groups.
 
-   The key component is the `imports.tf` file, which shows how to map existing Google Workspace resources to the module's resources. We also included a [Python script](https://github.com/masterpointio/terraform-googleworkspace-users-groups-automation/blob/main/examples/import-existing-org/debugging-script.py) to help debug by printing out the JSON objects as rendered by the Google APIs.
+   The key component is the [`imports.tf` file](https://masterpoint.io/blog/standard-tf-files/#importstf-resource-import-declarations), which shows how to map existing Google Workspace resources to the module's resources. We also included a [Python script](https://github.com/masterpointio/terraform-googleworkspace-users-groups-automation/blob/main/examples/import-existing-org/debugging-script.py) to help debug by printing out the JSON objects as rendered by the Google APIs.
 
    Since importing cloud resources into Terraform modules can be tricky, we documented our complete approach in [import-existing-org](https://github.com/masterpointio/terraform-googleworkspace-users-groups-automation/tree/main/examples/import-existing-org). The example includes these key files:
 
@@ -300,6 +300,8 @@ Below are more complex examples validating integration between different provide
    ```
 
 There are 4 more complex tests, helping us ensure this module won't break in the future.
+
+For runtime assertions about the deployed configuration, rather than module tests, use [Terraform `check` blocks](https://masterpoint.io/blog/understanding-terraform-check/).
 
 ### Design Decision #2 - Choosing Intuitive Terraform Variable Structures
 

--- a/content/blog/2025-09-17-fix-iam-trust-policy-errors-using-aws-sso-regional-arn.md
+++ b/content/blog/2025-09-17-fix-iam-trust-policy-errors-using-aws-sso-regional-arn.md
@@ -5,7 +5,7 @@ title: "Fix IAM Trust Policy Errors using AWS IAM Identity Center SSO Role Regio
 author: Yangci Ou
 slug: fix-iam-trust-policy-errors-with-aws-sso-regional-arn
 date: 2025-09-17
-# date_modified: 2025-xx-xx Be sure to use this if you've updated the post as this helps with SEO and index freshness
+date_modified: 2026-08-18
 description: If your IAM trust policy isn't working with AWS IAM Identity Center SSO roles, it might be because us-east-1 does not have the region in the ARN while other regions do.
 image: /img/updates/aws-iam-identity-center-sso-trust-policies.png
 callout: <p>👋 <b>If you're ready to take your infrastructure to the next level, we're here to help. We love to work together with engineering teams to help them build well-documented, scalable, automated IaC that make their jobs easier. <a href='/contact'>Get in touch!</a></p>
@@ -166,7 +166,7 @@ Here's an example IAM trust policy that allows SSO users from the Administrator 
 }
 ```
 
-If you're using Terraform or OpenTofu, here's a `data` source example:
+If you're using Terraform or OpenTofu, here's a `data` source example. In a conventionally structured configuration, this belongs in [`data.tf`](https://masterpoint.io/blog/standard-tf-files/#datatf-external-data-source-queries):
 
 ```hcl
 data "aws_iam_policy_document" "assume_role_policy" {
@@ -200,4 +200,4 @@ data "aws_iam_policy_document" "assume_role_policy" {
 }
 ```
 
-See more examples in the [AWS documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/referencingpermissionsets.html#custom-trust-policy-example).
+See more examples in the [AWS documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/referencingpermissionsets.html#custom-trust-policy-example). To make broader IAM configuration expectations explicit in Terraform runs, [Terraform `check` blocks](https://masterpoint.io/blog/understanding-terraform-check/) can validate conditions without tying them to a single resource.

--- a/content/blog/2026-06-22-using-opentofu-exclude-flag-isolate-performance-bottlenecks.md
+++ b/content/blog/2026-06-22-using-opentofu-exclude-flag-isolate-performance-bottlenecks.md
@@ -5,7 +5,7 @@ title: "Using OpenTofu's Exclude Flag to Isolate Performance Bottlenecks"
 author: Yangci Ou
 slug: using-opentofu-exclude-flag-isolate-performance-bottlenecks
 date: 2026-06-22
-date_modified: 2026-07-22 # Be sure to use this if you've updated the post as this helps with SEO and index freshness
+date_modified: 2026-08-18
 description: "Pair OpenTofu's exclude flag with OpenTelemetry tracing to isolate and prove Terraform performance bottlenecks. A real-world story of cutting plan times from 7 minutes to 2 by pinpointing AWS Route 53 API rate limiting."
 image: /img/updates/opentofu-exclude-flag-performance-bottlenecks/opentofu-exclude-flag.png
 callout: <p>👋 <b>If you're ready to take your infrastructure to the next level, we're here to help. We love to work together with engineering teams to help them build well-documented, scalable, automated IaC that make their jobs easier. <a href='/contact'>Get in touch!</a></p>
@@ -72,7 +72,7 @@ Looking at the OpenTelemetry traces, it showed that individual `aws_route53_reco
 
 Route 53 has a [five API requests per second rate limit, per account](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests), according to the official AWS documentation. We even filed a ticket with AWS support and spoke to an AWS Technical Account Manager (TAM) to see if there was any way to get it raised; the answer a flat "no" because DNS is critical infrastructure and 5 requests / second is the hard limit. This matches with other [engineers' experiences](https://github.com/rancher/rancher/issues/3257) as well.
 
-Buried in the 3,000 resources were 400 AWS Route 53 records, each as its own [TF resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record), and the provider read each record as individual API requests. 400 records (AWS API requests) at 5 requests per second is 80 seconds. But as mentioned above, in an enterprise environment, there are many dependencies, so the bottleneck compounds well past the theoretical 80 seconds.
+Buried in the 3,000 resources were 400 AWS Route 53 records, each as its own [TF resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record), and the provider read each record as individual API requests. 400 records (AWS API requests) at 5 requests per second is 80 seconds. But as mentioned above, in an enterprise environment, there are many dependencies, so the bottleneck compounds well past the theoretical 80 seconds. Once you've confirmed throttling is the culprit, [AWS adaptive retry mode](https://masterpoint.io/blog/aws-adaptive-retry-mode-terraform-throttled-api-requests/) can pace requests instead of letting retries repeatedly collide with the same rate limit.
 
 <div style="display:flex; align-items:center; justify-content:center; gap:1rem; flex-wrap:wrap; margin:2rem 0; padding:1.5rem; border-radius:10px; background:#f6faf7; border:1px solid #d6e6d8; text-align:center;">
   <span style="font-family:ui-monospace,'SF Mono',Menlo,Consolas,monospace; font-size:1.5rem; font-weight:800; color:#0e383a;">400 records</span>
@@ -89,7 +89,7 @@ Buried in the 3,000 resources were 400 AWS Route 53 records, each as its own [TF
 
 Because the existing setup is a [Terralith](https://masterpoint.io/blog/terralith-monolithic-terraform-architecture/) — a single monolithic Terraform root module that manages multitudes of infrastructure components through one shared state, so unrelated resources are tightly coupled and can't be changed in isolation — the fix required a refactor. We can take either of the following approaches, or both:
 
-- pull DNS out into its own small root module with its own isolated state
+- pull DNS out into its own [small root module with its own isolated state](https://masterpoint.io/blog/standard-tf-files/)
 - migrate the zone to [`aws_route53_records_exclusive`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_records_exclusive), which manages all records in a DNS zone as a single resource and [performs a batch AWS API request](https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListResourceRecordSets.html).
 
 Because any refactors would be non-trivial work, before making any architecture proposals, I wanted hard evidence to prove that Route 53 rate limiting / throttling was the bottleneck, not just a plausible story.

--- a/content/blog/2026-08-10-aws-adaptive-retry-mode-terraform-throttled-api-requests.md
+++ b/content/blog/2026-08-10-aws-adaptive-retry-mode-terraform-throttled-api-requests.md
@@ -5,7 +5,7 @@ title: "Using AWS Adaptive Retry Mode with Terraform for Throttled API Requests"
 author: Yangci Ou
 slug: aws-adaptive-retry-mode-terraform-throttled-api-requests
 date: 2026-08-10
-# date_modified: 2026-xx-xx Be sure to use this if you've updated the post as this helps with SEO and index freshness
+date_modified: 2026-08-18
 description: "Terraform's AWS provider retries throttled requests with exponential backoff, but each request backs off blind to the others. Adaptive retry mode adds a client-wide rate limiter that paces requests once throttling is detected to avoid being rate limited."
 image: /img/updates/aws-adaptive-retry-mode-terraform/aws-adaptive-retry-mode.png
 callout: "<p>👋 <b>Running into IaC performance issues at your organization?</b> <a href='/contact'>Get in touch</a>, we're the experts at helping organizations ship infrastructure fast and we'd love to chat!"
@@ -49,7 +49,7 @@ It's tempting to just bump max retries ([`max_retries`](https://registry.terrafo
 
 ### Why Not Just Lower Parallelism?
 
-The other knob is [`-parallelism`](https://developer.hashicorp.com/terraform/cli/commands/apply#parallelism-n), dropped from the default of 10 to 2 or 3 so fewer requests are in flight. That does reduce throttling, but it's a blunt instrument since parallelism is **global** while throttling almost never is. It's usually one or two API surfaces hitting their limits while everything else in the root module is perfectly fine, so **turning parallelism down slows every resource in the run to accommodate a small slice of it**, on every run, whether throttling shows up that day or not. Adaptive mode only kicks in once throttling is actually observed, and with provider aliases (more on that below) you can scope it to just the resources prone to rate limits while everything else runs at full speed.
+The other knob is [`-parallelism`](https://developer.hashicorp.com/terraform/cli/commands/apply#parallelism-n), dropped from the default of 10 to 2 or 3 so fewer requests are in flight. That does reduce throttling, but it's a blunt instrument since parallelism is **global** while throttling almost never is. It's usually one or two API surfaces hitting their limits while everything else in the root module is perfectly fine, so **turning parallelism down slows every resource in the run to accommodate a small slice of it**, on every run, whether throttling shows up that day or not. Adaptive mode only kicks in once throttling is actually observed, and with provider aliases (more on that below) you can scope it to just the resources prone to rate limits while everything else runs at full speed. If you need to establish that throttling is the bottleneck before changing retry behavior, [OpenTofu's `-exclude` flag can prove it](https://masterpoint.io/blog/using-opentofu-exclude-flag-isolate-performance-bottlenecks/).
 
 ## Enable It in the TF Provider Block, Not the Environment
 
@@ -59,7 +59,7 @@ You _can_ switch modes with the `AWS_RETRY_MODE` environment variable or the sha
 
 An env var is invisible in code & reviews, lives outside version control, and applies to **everything** in that process and shell: every provider configuration in the run, and even the AWS CLI in the same CI job. That's the opposite of what we want, since adaptive should only be on where it's necessary, and reviewers & future readers should be able to _easily see_ where it's on.
 
-The provider block gives you both visibility and scoping. Since v5 of the Terraform AWS provider, [`retry_mode` is a natively supported provider argument](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#retry_mode-1):
+The provider block gives you both visibility and scoping. Keep it in a dedicated `providers.tf` file alongside the rest of your [standard Terraform project structure](https://masterpoint.io/blog/standard-tf-files/). Since v5 of the Terraform AWS provider, [`retry_mode` is a natively supported provider argument](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#retry_mode-1):
 
 ```hcl
 provider "aws" {
@@ -98,4 +98,4 @@ This is because there are costs. **Typical operations get slower**, since delayi
 
 The important nuance is that adaptive mode only **pays a latency cost on requests that would have succeeded immediately anyway**. For resources that are already being throttled, there’s no real speed to preserve because standard retries are just bouncing off `Rate exceeded errors`.
 
-We have a practical rule at Masterpoint: keep the standard mode by default, and use adaptive retry mode where throttling occurs or is expected (Route53, we're looking at you). A paced request that succeeds is better than a burst of fast requests that AWS rejects.
+We have a practical rule at Masterpoint: keep the standard mode by default, and use adaptive retry mode where throttling occurs or is expected (Route53, we're looking at you). A paced request that succeeds is better than a burst of fast requests that AWS rejects. For a real-world performance turnaround involving a Terralith and AWS rate limits, see our [Cursor case study](https://masterpoint.io/case-studies/cursor/).

--- a/content/case-studies/cursor.md
+++ b/content/case-studies/cursor.md
@@ -139,7 +139,7 @@ With the first phase complete, Masterpoint turned to the platform.
 
 As mentioned above, TFC's ClickOps workspace management, SSO troubles, and resource-under-management pricing were all inhibiting Cursor's velocity and growth.
 
-Masterpoint recommended a move to [Spacelift](https://spacelift.io/) to address these issues.
+Masterpoint recommended a move to [Spacelift](https://spacelift.io/) to address these issues. For the migration tradeoffs and sequencing, see our guide on [moving off Terraform Cloud](https://masterpoint.io/blog/how-to-migrate-off-tfc/).
 
 The team kicked off the Spacelift migration in mid-December, starting with the groundwork:
 
@@ -167,7 +167,7 @@ After the migration was completed, Masterpoint continued to improved system usab
 - continuing to break up large state files into narrower root modules, allowing for faster plans and decreased blast radius
 - implementing child module versioning with [OCI registries](https://opentofu.org/docs/cli/oci_registries/module-package/) to enable staged rollouts and safer change control of critical TF resources
 - resolving the ECS drift issue by using the ["Task Definition Template Pattern"](https://newsletter.masterpoint.io/p/deploying-your-apps-into-ecs)
-- implementing OpenTofu's [OTel tracing](https://opentofu.org/docs/internals/tracing/) to find other performance bottlenecks and set up the Cursor team for longterm visibility into their IaC throughput
+- implementing OpenTofu's [OTel tracing](https://opentofu.org/docs/internals/tracing/) to find other performance bottlenecks and set up the Cursor team for longterm visibility into their IaC throughput; see how to [isolate and prove a bottleneck with OpenTofu's `-exclude` flag](https://masterpoint.io/blog/using-opentofu-exclude-flag-isolate-performance-bottlenecks/)
 
 Because Cursor's engineering team uses Cursor to write Terraform, Masterpoint embedded architectural knowledge directly into the codebase as AI agent skills and rules.
 

--- a/content/case-studies/power-digital.md
+++ b/content/case-studies/power-digital.md
@@ -135,7 +135,7 @@ Instead of one shared [Terralith](/blog/terralith-monolithic-terraform-architect
 {{< /csi-split >}}
 
 {{< csi-split eyebrow="Platform & Tooling" title="Terraform Cloud → <span class='csi-grad'>Spacelift</span> &amp; OpenTofu" media="/img/case-studies/spacelift.jpg" media_alt="Spacelift: provision, configure, govern" variant="light" flip="true" >}}
-Masterpoint recommended [Spacelift](https://spacelift.io/), a leading TACOS (Terraform Automation and Collaboration Software) platform:
+Masterpoint recommended [Spacelift](https://spacelift.io/), a leading TACOS (Terraform Automation and Collaboration Software) platform. For a detailed migration walkthrough, see [how to move off Terraform Cloud](https://masterpoint.io/blog/how-to-migrate-off-tfc/):
 
 - **Pricing that matches usage.** Terraform Cloud bills per resource, even when nothing changes — a client onboarded once and never updated is still billed. Spacelift bills on usage: annual costs dropped from ~$60,000 projected in 2024 to under $6,000, a gap that widens with every client added.
 - **Guardrails as code.** Operational and security policies enforced in the platform itself through [Open Policy Agent](https://www.openpolicyagent.org/).


### PR DESCRIPTION
## what

- Add contextual internal links across Terraform/OpenTofu foundations, architecture, performance, automation, and AI content.
- Connect relevant blog guidance with Cursor and Power Digital case-study proof.
- Refresh modification dates on updated blog posts.

## why

- Help readers move from a specific problem to the next useful guide or real-world outcome.
- Strengthen topic clusters without forcing unrelated archive content into the navigation.

## references

- No related GitHub issue.