### PR TITLE
feat(analytics): add Plausible alongside GA4

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ layouts/case-studies/immersive.html
 layouts/case-studies/single.html
 layouts/case-studies/_markup/render-link.html
 layouts/partials/case-study-entry.html
+layouts/partials/plausible.html

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -159,6 +159,8 @@
       src="//static.klaviyo.com/onsite/js/klaviyo.js?company_id=TTc7Za"
     ></script> -->
 
+    {{ partial "plausible.html" . }}
+
     <!-- Google tag (gtag.js) -->
     <script
       type="text/plain"

--- a/layouts/partials/plausible.html
+++ b/layouts/partials/plausible.html
@@ -1,0 +1,27 @@
+{{/*
+  Plausible Analytics.
+
+  Deliberately NOT consent-gated. Unlike the GA4/GTM blocks in head.html,
+  Plausible is cookieless and stores no personal data, so it does not require
+  consent. Adding type="text/plain" + data-category="analytics" here would make
+  it inherit the CookieConsent gate and defeat the reason we added it: seeing
+  the traffic GA4 never sees.
+
+  Served through the first-party proxy defined in netlify.toml so ad blockers
+  don't strip it. The paths below MUST stay in sync with those redirect rules.
+
+  Scroll depth and time-on-page are tracked automatically, no config needed.
+*/}}
+{{ if eq (os.Getenv "HUGO_ENV") "production" }}
+<!-- Privacy-friendly analytics by Plausible -->
+<script async src="/mpx/js/script.js"></script>
+<script>
+  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+  plausible.init({
+    endpoint: "/mpx/api/event",
+    outboundLinks: true,
+    fileDownloads: true,
+    formSubmissions: true
+  })
+</script>
+{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -60,6 +60,23 @@ status = 301
 force = true
 ########################################################
 
+########################################################
+# Plausible Analytics proxy. Serves the tracker first-party so ad blockers
+# don't strip it. These MUST stay above the catch-all 404 below, and the paths
+# MUST match the script src + endpoint in layouts/partials/plausible.html
+[[redirects]]
+from = "/mpx/js/script.js"
+to = "https://plausible.io/js/pa-J584RNJ6fxr4nE6Fry8ys.js"
+status = 200
+force = true
+
+[[redirects]]
+from = "/mpx/api/event"
+to = "https://plausible.io/api/event"
+status = 200
+force = true
+########################################################
+
 [[redirects]]
 from = "/*"
 to = "/404.html"


### PR DESCRIPTION
## what

- Adds Plausible Analytics to the site, running **in parallel** with the existing GA4/GTM setup. Nothing about GA4 changes.
- New `layouts/partials/plausible.html`, called from `head.html` just above the gtag block.
- Two `netlify.toml` rewrites under `/mpx/` that proxy the Plausible tracker and event endpoint through our own domain.
- Enables outbound link, file download, and form submission tracking. Scroll depth and time-on-page need no configuration.

## why

We use GA4 but effectively never log into it, and it has never been usable for a non-power-user. Plausible is the replacement candidate. This PR runs both side by side so we can compare before deciding whether to retire GA4.

Three deliberate choices, each worth a look during review:

**1. Plausible is not consent-gated, on purpose.**

GA4 and GTM load as `type="text/plain"` with `data-category="analytics"`, so CookieConsent blocks them until a visitor accepts. Plausible is cookieless and stores no personal data, so it does not require consent and loads unconditionally.

This is the main reason to adopt it: every visitor who ignores or declines the banner is currently invisible to GA4. **Expect the two tools to report very different totals.** Plausible will be meaningfully higher, and that gap is traffic GA4 has never shown us. Compare trends and rankings, not absolute numbers.

**2. Proxied first-party, and not installed via GTM.**

The `/mpx/` rewrites serve the tracker from our own domain so ad blockers do not strip it. Plausible's dashboard suggests a GTM install instead; that was rejected on two counts. Our GTM container is itself consent-gated, so Plausible would inherit the gate and lose benefit 1. And `googletagmanager.com` is widely ad-blocked, so the tracker would be blocked whenever GTM is, which the proxy cannot fix because the blocked resource would be the container rather than the tracker.

Note the rewrites must stay **above** the catch-all `/*` to `/404.html` rule, which would otherwise swallow those paths.

**3. Production only.**

Guarded on `HUGO_ENV`, which Netlify sets in the `production` and `split1` contexts but not in deploy previews. Without the guard, preview traffic would be attributed to the live site, since Plausible counts against the configured site rather than the actual hostname.

## verification

Built locally with `hugo --minify` (matching the Netlify build command) in both contexts:

- `HUGO_ENV=production`: Plausible renders with all four init options, GA4 untouched
- `HUGO_ENV` unset: Plausible absent entirely, GA4 untouched
- Rendered tag is a plain `<script async>` with no `type="text/plain"` and no `data-category`, confirming it sits outside the consent gate

`trunk check` passes clean on all three files.

Local build used cached Hugo v0.146.4 rather than the pinned v0.162.1, because `aqua install` currently fails to fetch that version (`hugo_extended_0.162.1_darwin-universal.tar.gz` is not published under that name). The template features used are old and stable, but the Netlify build is the real check.

## after merge

Worth confirming on the deployed site, especially the negative cases:

- `/mpx/js/script.js` returns 200 and `/mpx/api/event` returns 202
- With an ad blocker enabled, the event request still returns 202
- Decline the cookie banner, reload: GA4 stays silent, Plausible fires
- Open a deploy preview: no Plausible requests at all

If Netlify Asset Optimization rewrites the script URL, either disable `Bundle JS` / `Minify JS` or switch the `src` to an absolute URL.

## references

- [Plausible proxy guide for Netlify](https://plausible.io/docs/proxy/guides/netlify)
- [Plausible script configuration options](https://plausible.io/docs/script-extensions)
- [Plausible automatic scroll depth tracking](https://plausible.io/docs/scroll-depth)
- [CookieConsent script management](https://cookieconsent.orestbida.com/advanced/manage-scripts.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)